### PR TITLE
Remove `import b3d` from `setup.py`

### DIFF
--- a/b3d/__init__.py
+++ b/b3d/__init__.py
@@ -5,10 +5,12 @@
 # and any modifications thereto.  Any use, reproduction, disclosure or
 # distribution of this software and related documentation without an express
 # license agreement from NVIDIA CORPORATION is strictly prohibited.
+from pkg_resources import get_distribution
 
-__version__ = "0.0.1"
 from .renderer import *
 from .pose import *
 from .utils import *
 from .model import *
 from .mesh_library import *
+
+__version__ = get_distribution('b3d').version

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ trimesh
 matplotlib
 scipy
 ninja
+scikit-learn

--- a/setup.py
+++ b/setup.py
@@ -8,9 +8,6 @@
 
 import os
 import setuptools
-import b3d
-
-import os
 
 with open('requirements.txt') as f:
     required = f.read().splitlines()
@@ -18,9 +15,10 @@ with open('requirements.txt') as f:
 with open("README.md", "r") as fh:
     long_description = fh.read()
 
+
 setuptools.setup(
     name="b3d",
-    version=b3d.__version__,
+    version="0.0.1",
     packages=setuptools.find_packages(),
     package_data={
         "b3d": [


### PR DESCRIPTION
Currently, to install `b3d`, setup.py needs to import `b3d` itself, which can trigger `ModuleNotFoundError` unless users have manually installed the dependencies from `requirements.txt`: e.g. here's the error I encountered during install, which led to this PR:

```python
❯ pip install -e .                                                                                             
Obtaining file:///home/<hidden_paths>/b3d
  Preparing metadata (setup.py) ... error
  error: subprocess-exited-with-error
  
  × python setup.py egg_info did not run successfully.
  │ exit code: 1
  ╰─> [10 lines of output]
      Traceback (most recent call last):
        File "<string>", line 2, in <module>
        File "<pip-setuptools-caller>", line 34, in <module>
        File "/home/<hidden_paths>b3d/setup.py", line 11, in <module>
          import b3d
        File "/home/<hidden_paths>/b3d/b3d/__init__.py", line 11, in <module>
          from .pose import *
        File "/home/<hidden_paths>/b3d/b3d/pose.py", line 9, in <module>
          from tensorflow_probability.substrates import jax as tfp
      ModuleNotFoundError: No module named 'tensorflow_probability'
      [end of output]
  
  note: This error originates from a subprocess, and is likely not a problem with pip.
error: metadata-generation-failed

× Encountered error while generating package metadata.
╰─> See above for output.

note: This is an issue with the package mentioned above, not pip.
hint: See above for details.
```

Despite that we have configured `setup.py` to read dependencies from `requirements.txt`, Pip failed to get them because the `ModuleNotFoundError` was raised before it.

It seems like in `setup.py`, `b3d` pacakge is only used to fill in the version metadata. The proposed change is to sync from the other way around, by setting the version in `setup.py` and read it in `b3d/__init__.py`.