### PR TITLE
Debugging performance discrepancy between PyTorch and JAX variants of NVDiffrast

### DIFF
--- a/b3d/nvdiffrast_original/jax/jax_rasterize_gl.cpp
+++ b/b3d/nvdiffrast_original/jax/jax_rasterize_gl.cpp
@@ -18,7 +18,6 @@ RasterizeGLStateWrapper::RasterizeGLStateWrapper(bool enableDB, bool automatic_,
     cudaDeviceIdx = cudaDeviceIdx_;
     memset(pState, 0, sizeof(RasterizeGLState));
     pState->enableDB = enableDB ? 1 : 0;
-    std::cout << "initialization" << std::endl;
     rasterizeInitGLContext(NVDR_CTX_PARAMS, *pState, cudaDeviceIdx_);
     releaseGLContext();
 }
@@ -63,10 +62,8 @@ void jax_rasterize_fwd_original_gl(cudaStream_t stream,
     resolution.resize(2);
     int ranges[2*d.num_objects];
 
-    cudaStreamSynchronize(stream);
     NVDR_CHECK_CUDA_ERROR(cudaMemcpy(&resolution[0], _resolution, 2 * sizeof(int), cudaMemcpyDeviceToHost));
     NVDR_CHECK_CUDA_ERROR(cudaMemcpy(&ranges[0], _ranges, 2 * d.num_objects * sizeof(int), cudaMemcpyDeviceToHost));
-    cudaStreamSynchronize(stream);
 \
     // std::cout << "num_images: " << d.num_images << std::endl;
     // std::cout << "num_objects: " << d.num_objects << std::endl;
@@ -89,7 +86,7 @@ void jax_rasterize_fwd_original_gl(cudaStream_t stream,
     // const at::cuda::OptionalCUDAGuard device_guard(at::device_of(pos));
     RasterizeGLState& s = *stateWrapper.pState;
 
-    
+
     int posCount = 4 * d.num_images * d.num_vertices;
     int triCount = 3 * d.num_triangles;
 
@@ -109,7 +106,7 @@ void jax_rasterize_fwd_original_gl(cudaStream_t stream,
     const int32_t* rangesPtr = 0;
     const int32_t* triPtr = tri;
     int vtxPerInstance = d.num_vertices;
-    rasterizeRender(NVDR_CTX_PARAMS, s, stream, posPtr, posCount, vtxPerInstance, triPtr, triCount, rangesPtr, width, height, depth, peeling_idx);
+    rasterizeRender(NVDR_CTX_PARAMS, s, stream, posPtr, posCount, vtxPerInstance, triPtr, triCount, ranges, width, height, depth, peeling_idx);
 
     // std::cout << "render" << std::endl;
 


### PR DESCRIPTION
The following notes are modified from the [related Notion card](https://www.notion.so/chi-mit/Debugging-performance-discrepancy-between-NVDiffrast-Torch-and-JAX-185148d4891b465da4e53f8156cf0349?pvs=4)

Benchmarking script: [b3d/test/test_renderer_fps.py](https://github.com/probcomp/b3d/blob/main/test/test_renderer_fps.py)

## Before

Output of `python test/test_renderer_fps.py`:

```
Torch
Resolution: 1024x1024, FPS: 2289.8922289071115
Resolution: 512x512, FPS: 2861.1917766822266
Resolution: 256x256, FPS: 2985.5311176707996
Resolution: 128x128, FPS: 2893.421633554084
Resolution: 64x64, FPS: 3079.929917213607
Resolution: 32x32, FPS: 3096.469365336231
JAX NVdiffrast Original
Resolution: 1024x1024, FPS: 911.1996657873235
Resolution: 512x512, FPS: 977.560392142513
Resolution: 256x256, FPS: 979.7225675373279
Resolution: 128x128, FPS: 1028.6825650452315
Resolution: 64x64, FPS: 1068.0791248191986
Resolution: 32x32, FPS: 1055.3279884702326
JAX
Resolution: 1024x1024, FPS: 801.9614317778946
Resolution: 512x512, FPS: 979.8047307075504
Resolution: 256x256, FPS: 1003.173856036569
Resolution: 128x128, FPS: 1028.2283884215265
Resolution: 64x64, FPS: 1028.7337827974036
Resolution: 32x32, FPS: 996.5328208316811
JAX through torch DLPACK
Resolution: 1024x1024, FPS: 2133.707747992481
Resolution: 512x512, FPS: 2451.4316807922564
Resolution: 256x256, FPS: 2519.926342256174
Resolution: 128x128, FPS: 2552.6166684620107
Resolution: 64x64, FPS: 2549.680826683509
Resolution: 32x32, FPS: 2548.86892264312
```

## First change: Using `lax.scan` instead of for loop

This should let us get rid of some overhead from XLA…

(Note: `lax.while_loop` should achieve similar effect)

Related:
- Documentation for [`jax.lax.scan`](https://jax.readthedocs.io/en/latest/_autosummary/jax.lax.scan.html) and [`jax.lax.while_loop`](https://jax.readthedocs.io/en/latest/_autosummary/jax.lax.while_loop.html)
- https://github.com/google/jax/issues/427

```markdown
Torch
Resolution: 1024x1024, FPS: 2279.370582816835
Resolution: 512x512, FPS: 2852.7848003977556
Resolution: 256x256, FPS: 2974.3082078999955
Resolution: 128x128, FPS: 3037.0707208211807
Resolution: 64x64, FPS: 3070.222029625422
Resolution: 32x32, FPS: 3086.450405131643
JAX NVdiffrast Original (with lax.scan)
Resolution: 1024x1024, FPS: 1461.7752904693164
Resolution: 512x512, FPS: 1567.3793478171508
Resolution: 256x256, FPS: 1674.5947965957964
Resolution: 128x128, FPS: 1648.1440076389122
Resolution: 64x64, FPS: 1716.1011730751213
Resolution: 32x32, FPS: 1643.5740481460973
JAX (with lax.scan)
Resolution: 1024x1024, FPS: 733.1984047710031
Resolution: 512x512, FPS: 843.3599566969871
Resolution: 256x256, FPS: 875.2602479306937
Resolution: 128x128, FPS: 890.9948700344285
Resolution: 64x64, FPS: 881.9893748380823
Resolution: 32x32, FPS: 881.0593119580953
JAX through torch DLPACK
Resolution: 1024x1024, FPS: 2138.8324983108323
Resolution: 512x512, FPS: 2495.4761617194094
Resolution: 256x256, FPS: 2419.0390063395685
Resolution: 128x128, FPS: 2492.704287093078
Resolution: 64x64, FPS: 2331.9294956581107
Resolution: 32x32, FPS: 2015.288947657216
```
    

## Second change: Removing unnecessary`cudaStreamSynchronize(stream)`

*Disclaimer: I’m not certain about this change, since I’m new to CUDA programming.* 

It looks like we’re calling `cudaStreamSynchronize(stream)` a lot in the definition of the JAX rasterize wrapper code (e.g. [`jax_rasterize_gl.cpp`](https://github.com/probcomp/b3d/blob/main/b3d/nvdiffrast_original/jax/jax_rasterize_gl.cpp#L66)). However, except for debugging, we probably don’t want to block CPU until the stream has finished execution?

By deleting `cudaStreamSynchronize(stream)` from the C++ implementations, we can see another performance bump on the JAX rasterizer:

```markdown
Torch
Resolution: 1024x1024, FPS: 2252.760290699954
Resolution: 512x512, FPS: 2845.9962164700264
Resolution: 256x256, FPS: 2973.428943105569
Resolution: 128x128, FPS: 3034.5482222337982
Resolution: 64x64, FPS: 3070.316423172255
Resolution: 32x32, FPS: 3083.6706696094448
JAX NVdiffrast Original (+lax.scan, -stream synchronize)
Resolution: 1024x1024, FPS: 1990.3167714979204
Resolution: 512x512, FPS: 2224.1793298885977
Resolution: 256x256, FPS: 2351.079125399175
Resolution: 128x128, FPS: 2398.370552843241
Resolution: 64x64, FPS: 2321.356760696755
Resolution: 32x32, FPS: 2422.3360854559483
JAX (with lax.scan)
Resolution: 1024x1024, FPS: 719.8324700203096
Resolution: 512x512, FPS: 813.4414067909095
Resolution: 256x256, FPS: 866.9300890368162
Resolution: 128x128, FPS: 886.0318977938898
Resolution: 64x64, FPS: 874.738734019031
Resolution: 32x32, FPS: 879.9639144436635
JAX through torch DLPACK
Resolution: 1024x1024, FPS: 2150.022118915184
Resolution: 512x512, FPS: 2510.152393628481
Resolution: 256x256, FPS: 2445.71392585604
Resolution: 128x128, FPS: 2503.38057221437
Resolution: 64x64, FPS: 2480.861957195516
Resolution: 32x32, FPS: 2505.917216327311
```

- Note 1: It seems like removing all Stream synchronization from b3d version of the renderer can result in nondeterministic CUDA error. I haven’t take a super close look into the b3d-version of the renderer (aka `JAX`) to find out what are removable, so the numbers are not included above. Though even when it doesn't error out, we don't see the same performance boost:
    
    ```markdown
    JAX (+lax.scan, -stream synchronize)
   Resolution: 1024x1024, FPS: 870.6132853762722
   Resolution: 512x512, FPS: 1024.7730832097457
   Resolution: 256x256, FPS: 1076.2360742862113
   Resolution: 128x128, FPS: 1100.484477183132
   Resolution: 64x64, FPS: 1077.2718283270622
   Resolution: 32x32, FPS: 1078.6340247080325
    ```
    
- Note 2: After removing the unnecessary `cudaStreamSynchronize` call, the output of JAX NVDiffrast is still the same as the PyTorch version:
    
    ```markdown
    Torch
    tensor(1.0373e+10, device='cuda:0')
    Resolution: 1024x1024, FPS: 2289.497242321952
    tensor(2.5595e+09, device='cuda:0')
    Resolution: 512x512, FPS: 2802.909093825159
    tensor(6.5713e+08, device='cuda:0')
    Resolution: 256x256, FPS: 2985.9902140089316
    tensor(1.6092e+08, device='cuda:0')
    Resolution: 128x128, FPS: 2934.1425775210882
    tensor(36074596., device='cuda:0')
    Resolution: 64x64, FPS: 3080.278247790938
    tensor(15485054., device='cuda:0')
    Resolution: 32x32, FPS: 3090.753539481625
    JAX NVdiffrast Original (+lax.scan, -stream synchronize)
    10227558000.0
    Resolution: 1024x1024, FPS: 1974.4693350983327
    2544131600.0
    Resolution: 512x512, FPS: 2218.886785725244
    655813100.0
    Resolution: 256x256, FPS: 2291.8904977588204
    160595570.0
    Resolution: 128x128, FPS: 2384.597322781374
    36074596.0
    Resolution: 64x64, FPS: 2390.8363615635644
    15252779.0
    Resolution: 32x32, FPS: 2363.0174571177786
    ```

:) I'm just pushing the code here so people can give it a try. Even though we're only tweaking the rasterization operator here, this can give us some ideas about how to improve the performance on the overall rendering pipeline. @nishadgothoskar 

