### PR TITLE
Add instance creation instructions to README, depend on artifact registry genjax

### DIFF
--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -1,0 +1,59 @@
+# Developer's Guide
+
+This guide describes how to complete various tasks you'll encounter when working
+on the b3d codebase.
+
+## Commit Hooks
+
+We use [pre-commit](https://pre-commit.com/) to manage a series of git pre-commit hooks for the
+project; for example, each time you commit code, the hooks will make sure that your python is
+formatted properly. If your code isn't, the hook will format it, so when you try to commit the
+second time you'll get past the hook.
+
+All hooks are defined in `.pre-commit-config.yaml`. To install these hooks, install `pre-commit` if
+you don't yet have it. I prefer using [pipx](https://github.com/pipxproject/pipx) so that
+`pre-commit` stays globally available.
+
+```bash
+pipx install pre-commit
+```
+
+Then install the hooks with this command:
+
+```bash
+pre-commit install
+```
+
+Now they'll run on every commit. If you want to run them manually, run the following command:
+
+```bash
+pre-commit run --all-files
+```
+
+## Installing CUDA 12.3+
+
+These instructions are for older gcloud machines than the one specified in README.md. If you created an instance using those instructions, you should _not_ have to do this.
+
+To diagnose errors from an older-than-12.3 CUDA version, run `nvidia-smi`:
+
+```sh
++-----------------------------------------------------------------------------------------+
+| NVIDIA-SMI 550.54.15              Driver Version: 550.54.15      CUDA Version: 12.4     |
+|-----------------------------------------+------------------------+----------------------+
+```
+
+and verify that `CUDA Version: xx.x` is >= 12.3.
+
+If not, ensure your NVIDIA GPU supports CUDA 12.3+ and install a NVIDIA driver version compatible with 12.3+. For GCP instances, use:
+
+```sh
+sudo sh -c "echo 'export DRIVER_VERSION=550.54.15' > /opt/deeplearning/driver-version.sh"
+/opt/deeplearning/install-driver.sh
+```
+
+If the above commands fail, then first uninstall the existing driver by running the below, then try again.
+
+```sh
+/opt/deeplearning/uninstall-driver.sh
+sudo reboot
+```

--- a/README.md
+++ b/README.md
@@ -38,9 +38,25 @@ gcloud compute config-ssh
 ssh $INSTANCE_NAME.$ZONE.$PROJECT_ID
 ```
 
+## Environment Variables
+
+Add the following to your bash_rc:
+
+```sh
+export XLA_PYTHON_CLIENT_PREALLOCATE="false"
+export XLA_PYTHON_CLIENT_ALLOCATOR="platform"
+```
+
 # Installing b3d
 
-On the machine, close the `b3d` repo:
+`b3d`'s GenJAX dependency is hosted in Google Artifact Registry. To configure your machine to access the package:
+
+- Check if you can access the [GenJAX Users
+  Group](https://groups.google.com/u/1/a/chi-fro.org/g/genjax-users), and if not, run `\invite-genjax <google-account-email>` in any channel in the the probcomp Slack
+- [Install the Google Cloud command line tools](https://cloud.google.com/sdk/docs/install).
+- Run `gcloud auth application-default login`.  (This command needs to be rerun ever time your machine reboots.)
+
+Next, on the machine, close the `b3d` repo:
 
 ```sh
 git clone https://github.com/probcomp/b3d.git
@@ -51,15 +67,7 @@ Create and activate `b3d` conda environment:
 
 ```sh
 conda create -n b3d python=3.12
-conda activate b3d
 ```
-
-`b3d`'s GenJAX dependency is hosted in Google Artifact Registry. To configure your machine to access the package:
-
-- Check if you can access the [GenJAX Users
-  Group](https://groups.google.com/u/1/a/chi-fro.org/g/genjax-users), and if not, run `\invite-genjax <google-account-email>` in any channel in the the probcomp Slack
-- [Install the Google Cloud command line tools](https://cloud.google.com/sdk/docs/install).
-- Run `gcloud auth application-default login`.  (This command needs to be rerun ever time your machine reboots.)
 
 When that completes, run the install script:
 
@@ -67,13 +75,10 @@ When that completes, run the install script:
 bash -i install.sh
 ```
 
-## Environment Variables
-
-Add the following to your bash_rc:
+Then activate the conda environment:
 
 ```sh
-export XLA_PYTHON_CLIENT_PREALLOCATE="false"
-export XLA_PYTHON_CLIENT_ALLOCATOR="platform"
+conda activate b3d
 ```
 
 ## Visualizer

--- a/README.md
+++ b/README.md
@@ -4,57 +4,83 @@
   <img src="https://github.com/probcomp/b3d/assets/66085644/53d4f644-530e-41b9-87f9-814064f12230" alt="animated" width="150%" />
 </p>
 
-# b3d repository
+# b3d
+
 This repository contains code for Bayesian 3D inverse graphics.
 
-The `b3d/bayes3d/` subdirectory contains code for the `bayes3d` project,
-and the `b3d/chisight/` subdirectory contains code for post-bayes3D
-ChiSight systems (currently, SAMA4D).
+The `b3d/bayes3d/` subdirectory contains code for the `bayes3d` project, and the `b3d/chisight/` subdirectory contains code for post-bayes3D ChiSight systems (currently, SAMA4D).
+
+## GCloud Machine
+
+Run the following command to launch your instance:
+
+```bash
+export ZONE="us-west1-a"
+
+# Make sure to replace the value with a unique name!
+export INSTANCE_NAME="your-instance-name-here"
+
+gcloud compute instances create $INSTANCE_NAME \
+  --zone=$ZONE \
+  --image-family="common-cu123-ubuntu-2204-py310" \
+  --image-project=deeplearning-platform-release \
+  --maintenance-policy=TERMINATE \
+  --boot-disk-size=400GB \
+  --machine-type g2-standard-32 \
+  --accelerator="type=nvidia-l4,count=1" \
+  --metadata="install-nvidia-driver=True"
+```
+
+to ssh into your new machine, run:
+
+```bash
+gcloud compute config-ssh
+ssh $INSTANCE_NAME.$ZONE.$PROJECT_ID
+```
 
 # Installing b3d
 
-Create `b3d` conda environment:
-```
-conda create -n b3d python=3.12
+On the machine, close the `b3d` repo:
+
+```sh
+git clone https://github.com/probcomp/b3d.git
+cd b3d
 ```
 
-Run install script:
+Create and activate `b3d` conda environment:
+
+```sh
+conda create -n b3d python=3.12
+conda activate b3d
 ```
+
+`b3d`'s GenJAX dependency is hosted in Google Artifact Registry. To configure your machine to access the package:
+
+- Check if you can access the [GenJAX Users
+  Group](https://groups.google.com/u/1/a/chi-fro.org/g/genjax-users), and if not, run `\invite-genjax <google-account-email>` in any channel in the the probcomp Slack
+- [Install the Google Cloud command line tools](https://cloud.google.com/sdk/docs/install).
+- Run `gcloud auth application-default login`.  (This command needs to be rerun ever time your machine reboots.)
+
+When that completes, run the install script:
+
+```sh
 bash -i install.sh
 ```
 
+## Environment Variables
 
-### Installing CUDA 12.3+
-Run `nvidia-smi`
-```
-+-----------------------------------------------------------------------------------------+
-| NVIDIA-SMI 550.54.15              Driver Version: 550.54.15      CUDA Version: 12.4     |
-|-----------------------------------------+------------------------+----------------------+
-```
-and verify that `CUDA Version: xx.x` is >= 12.3.
-
-If not, ensure your NVIDIA GPU supports CUDA 12.3+ and install a NVIDIA driver version compatible with 12.3+. For GCP instances, use:
-```
-sudo sh -c "echo 'export DRIVER_VERSION=550.54.15' > /opt/deeplearning/driver-version.sh"
-/opt/deeplearning/install-driver.sh
-```
-If the above commands fail, then first uninstall the existing driver by running the below, then try again.
-```
-/opt/deeplearning/uninstall-driver.sh
-sudo reboot
-```
-
-### Environment Variables
 Add the following to your bash_rc:
-```
+
+```sh
 export XLA_PYTHON_CLIENT_PREALLOCATE="false"
 export XLA_PYTHON_CLIENT_ALLOCATOR="platform"
 ```
 
+## Visualizer
 
-### Visualizer
 Tunnel port `8812` for Rerun visualization by adding the `RemoteForward`line to your ssh config:
-```
+
+```sh
 Host xx.xx.xxx.xxx
     HostName xx.xx.xxx.xxx
     IdentityFile ~/.ssh/id_rsa
@@ -63,6 +89,7 @@ Host xx.xx.xxx.xxx
 ```
 
 Install rerun on local machine `pip install rerun-sdk` and open viewer:
-```
+
+```sh
 rerun --port 8812
 ```

--- a/install.sh
+++ b/install.sh
@@ -1,7 +1,13 @@
 #!/bin/bash
 conda activate b3d
-sudo apt-get install mesa-common-dev libegl1-mesa-dev libglfw3-dev libgl1-mesa-dev libglu1-mesa-dev
-sudo apt-get install ffmpeg
+sudo apt-get install  -y --no-install-recommends \
+    ffmpeg \
+    mesa-common-dev \
+    libegl1-mesa-dev \
+    libglfw3-dev \
+    libgl1-mesa-dev \
+    libglu1-mesa-dev
+
 pip install keyring keyrings.google-artifactregistry-auth
 pip install -e . --extra-index-url https://us-west1-python.pkg.dev/probcomp-caliban/probcomp/simple/
 b3d_pull

--- a/install.sh
+++ b/install.sh
@@ -2,6 +2,7 @@
 conda activate b3d
 sudo apt-get install mesa-common-dev libegl1-mesa-dev libglfw3-dev libgl1-mesa-dev libglu1-mesa-dev
 sudo apt-get install ffmpeg
-pip install -e .
+pip install keyring keyrings.google-artifactregistry-auth
+pip install -e . --extra-index-url https://us-west1-python.pkg.dev/probcomp-caliban/probcomp/simple/
 b3d_pull
 mkdir -p assets/test_results

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ setuptools.setup(
         "https://storage.googleapis.com/jax-releases/jax_cuda_releases.html"
     ],
     install_requires=[
-        "genjax @ git+ssh://git@github.com/probcomp/genjax.git@v0.4.0",
+        "genjax==0.4.0",
         "rerun-sdk==0.16.1",
         "tqdm==4.66.2",
         "numpy==1.26.4",

--- a/setup.py
+++ b/setup.py
@@ -60,7 +60,6 @@ setuptools.setup(
         "optax==0.2.2",
         "fire==0.6.0",
         "torch==2.2.2",
-        "torchaudio==2.2.2",
         "torchvision==0.17.2",
         "jax[cuda12]==0.4.28",
         "natsort",


### PR DESCRIPTION
This PR:

- adds instructions for how to launch a gcloud VM that works with b3d
- organizes the README and makes setup more explicit
- removes an unused torchaudio dependency
- updates the `genjax` dependency to come from artifact registry vs requiring a git checkout