### PR TITLE
Upgrade to GenJAX 0.5.0, fix unsupported escape sequences

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,9 +53,6 @@ dependencies = [
 b3d_pull = "b3d.bucket_utils.b3d_pull:download_from_bucket"
 b3d_push = "b3d.bucket_utils.b3d_push:upload_to_bucket"
 
-# [tool.setuptools]
-# package-dir = {"" = "src"}
-
 [tool.setuptools.package-data]
 "b3d" = [
     "nvdiffrast/common/*.h",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ classifiers = [
     "Programming Language :: Python :: 3.12"
 ]
 dependencies = [
-    "genjax==0.4.0",
+    "genjax==0.5.0",
     "rerun-sdk==0.16.1",
     "tqdm==4.66.2",
     "numpy==1.26.4",
@@ -77,8 +77,8 @@ b3d_push = "b3d.bucket_utils.b3d_push:upload_to_bucket"
     "nvdiffrast/jax/*.cpp",
 ]
 
-[tool.setuptools_scm]
-write_to = "b3d/_version.py"
-
 [tool.pytest.ini_options]
 testpaths = ["tests"]
+
+[tool.pyright]
+typeCheckingMode = "standard"

--- a/src/b3d/chisight/sparse/gps_utils.py
+++ b/src/b3d/chisight/sparse/gps_utils.py
@@ -50,13 +50,13 @@ def gaussian_restriction_to_ray(
     the mean `mu` and standard deviation `sig`, such that,
     parameterizing they ray by $r(t) = o +t*v$, we have
     $$
-        N( r(t) | \tilde\mu, cov) = w * N(t | \mu, \sigma)
+        N( r(t) | \\tilde\\mu, cov) = w * N(t | \\mu, \\sigma)
     $$
     where
     $$
-        w = N( r(\mu) | \tilde\mu, cov) /  N(\mu, \mu, \sigma).
+        w = N( r(\\mu) | \\tilde\\mu, cov) /  N(\\mu, \\mu, \\sigma).
     $$
-    Note that $\mu$ is the maximum of both the nominator and denominator.
+    Note that $\\mu$ is the maximum of both the nominator and denominator.
     Also note that the first equation implies that the integral of
     the Gaussian along the ray is given by $w$.
     """

--- a/src/b3d/io/video_input.py
+++ b/src/b3d/io/video_input.py
@@ -13,7 +13,7 @@ class VideoInput:
         x-axis pointing to the right, and y-axis pointing down. This is the OpenCV convention.
     Quaternions. We follow scipy.spatial.transform.Rotation.from_quat which uses scalar-last (x, y, z, w)
     Camera Intrinsics. We store it as an array of shape (8,) containing width, height, fx, fy, cx, cy, near, far.
-        The camera matrix is given by: $$ K = \begin{bmatrix} f_x & 0 & c_x \ 0 & f_y & c_y \ 0 & 0 & 1 \end{bmatrix} $$
+        The camera matrix is given by: $$ K = \\begin{bmatrix} f_x & 0 & c_x \\ 0 & f_y & c_y \\ 0 & 0 & 1 \\end{bmatrix} $$
     Spatial units. Spatial units are measured in meters (if not indicated otherwise).
 
     **Attributes:**

--- a/src/b3d/pose/core.py
+++ b/src/b3d/pose/core.py
@@ -26,7 +26,7 @@ def choose_good_quat(q):
     so we'll iteratively resolve that as well.
 
     Recall that SO(3) is isomorphic to  S^3/x~-x and
-    also to D^3/~ where x~-x for x in S^2 = \partial D^3.
+    also to D^3/~ where x~-x for x in S^2 = \\partial D^3.
     """
     return jnp.where(
         q[..., [3]] != 0,
@@ -180,7 +180,7 @@ class Pose:
         chooses from {q, -q} s.t. q[3] >= 0. Note that if q[3]==0 there is still ambiguity.
 
         Recall that SO(3) is isomorphic to  S^3/x~-x and
-        also to D^3/~ where x~-x for x in S^2 = \partial D^3.
+        also to D^3/~ where x~-x for x in S^2 = \\partial D^3.
         """
         quat = self.quat / jnp.linalg.norm(self.quat, axis=-1, keepdims=True)
         return Pose(self.pos, choose_good_quat(quat))

--- a/tests/test_pose.py
+++ b/tests/test_pose.py
@@ -55,7 +55,7 @@ class PoseTests(unittest.TestCase):
             which represents the same rotation.
 
             Recall that SO(3) is isomorphic to  S^3/x~-x and
-            also to D^3/~ where x~-x for x in S^2 = \partial D^3.
+            also to D^3/~ where x~-x for x in S^2 = \\partial D^3.
             """
             # TODO: choose good representative if q[3]==0 there is still ambiguity.
             return jnp.where(q[..., [3]] == 0, q, jnp.sign(q[..., [3]]) * q)


### PR DESCRIPTION
This PR:

- Upgrades b3d to https://github.com/probcomp/genjax/releases/tag/v0.5.0
- escapes math backslashes in python strings - these were causing "unsupported literal" exceptions on import

GenJAX 0.5.0 doesn't break anything that b3d uses, and includes some nice-to-have type upgrades that will make development a bit more pleasant.