### PR TITLE
Turn on ruff linter, fix final 7 bugs

### DIFF
--- a/.github/workflows/ruff.yml
+++ b/.github/workflows/ruff.yml
@@ -1,0 +1,22 @@
+name: Ruff linter
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+jobs:
+  ruff:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+
+    - uses: actions/setup-python@v4
+      with:
+        python-version: 3.11.5
+
+    - uses: chartboost/ruff-action@v1
+      with:
+        version: 0.5.4
+        args: --output-format github

--- a/.github/workflows/ruff.yml
+++ b/.github/workflows/ruff.yml
@@ -19,4 +19,4 @@ jobs:
     - uses: chartboost/ruff-action@v1
       with:
         version: 0.5.4
-        args: --output-format github
+        args: check --output-format github

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,5 +10,9 @@ repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.5.4
     hooks:
+      - id: ruff
+        types_or: [ python, pyi ]
+        args: [ --fix ]
+
       - id: ruff-format
         types_or: [ python, pyi ]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,3 +1,6 @@
+ci:
+    skip: [ruff]
+
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.6.0

--- a/demos/sparse_model/sparse_model_cotracker.py
+++ b/demos/sparse_model/sparse_model_cotracker.py
@@ -382,8 +382,6 @@ rr.log(
     ),
 )
 
-print(loss_function(SECOND_T, params, cluster_assignments, gt_info))
-
 cluster_assignments = cluster_assignments.at[top_indices].set(
     cluster_assignments.max() + 1
 )

--- a/demos/tracking_online_learning.py
+++ b/demos/tracking_online_learning.py
@@ -244,14 +244,14 @@ for reaquisition_phase in range(len(REAQUISITION_TS) - 1):
     # )
 
     # Outliers are AND of the RGB and Depth outlier masks
-    outler_mask = outliers
-    rr.log("outliers", rr.Image(jnp.tile((outler_mask * 1.0)[..., None], (1, 1, 3))))
+    outlier_mask = outliers
+    rr.log("outliers", rr.Image(jnp.tile((outlier_mask * 1.0)[..., None], (1, 1, 3))))
 
     # Get the point cloud corresponding to the outliers
     point_cloud = b3d.xyz_from_depth(trace["observed_rgb_depth"][1], fx, fy, cx, cy)[
-        outler_mask
+        outlier_mask
     ]
-    point_cloud_colors = trace["observed_rgb_depth"][0][outler_mask]
+    point_cloud_colors = trace["observed_rgb_depth"][0][outlier_mask]
 
     # Segment the outlier cloud.
     assignment = b3d.segment_point_cloud(point_cloud)
@@ -334,9 +334,10 @@ for i in tqdm(range(len(inference_data_over_time))):
     )[0]
     b3d.rerun_visualize_trace_t(trace, t)
     rr.set_time_sequence("frame", t)
-    outler_mask = jnp.logical_and(rgb_outliers, depth_outliers)
 
     rgb_inliers, rgb_outliers = b3d.get_rgb_inlier_outlier_from_trace(trace)
     depth_inliers, depth_outliers = b3d.get_depth_inlier_outlier_from_trace(trace)
 
-    rr.log("outliers", rr.Image(jnp.tile((outler_mask * 1.0)[..., None], (1, 1, 3))))
+    outlier_mask = jnp.logical_and(rgb_outliers, depth_outliers)
+
+    rr.log("outliers", rr.Image(jnp.tile((outlier_mask * 1.0)[..., None], (1, 1, 3))))

--- a/src/b3d/io/utils.py
+++ b/src/b3d/io/utils.py
@@ -173,6 +173,14 @@ def video_input_from_mp4(
     reverse_color_channel=False,
 ):
     info = load_video_info(video_fname)
+
+    if info is None:
+        return None
+
+    if times is None:
+        T = info.timesteps
+        times = np.arange(T, step=step)
+
     intr = np.load(intrinsics_fname, allow_pickle=True)
     vid = load_video_to_numpy(
         video_fname,
@@ -181,7 +189,9 @@ def video_input_from_mp4(
         reverse_color_channel=reverse_color_channel,
     )
 
-    return VideoInput(rgb=vid, camera_intrinsics_rgb=intr, fps=info.fps)
+    fps = info.fps / (times[1] - times[0])
+
+    return VideoInput(rgb=vid, camera_intrinsics_rgb=intr, fps=fps)
 
 
 def plot_video_summary(

--- a/src/b3d/io/utils.py
+++ b/src/b3d/io/utils.py
@@ -172,9 +172,6 @@ def video_input_from_mp4(
     downsize=1,
     reverse_color_channel=False,
 ):
-    if times is None:
-        times = np.arange(T, step=step)
-
     info = load_video_info(video_fname)
     intr = np.load(intrinsics_fname, allow_pickle=True)
     vid = load_video_to_numpy(
@@ -184,9 +181,7 @@ def video_input_from_mp4(
         reverse_color_channel=reverse_color_channel,
     )
 
-    fps = info.fps / (times[1] - times[0])
-
-    return VideoInput(rgb=vid, camera_intrinsics_rgb=intr, fps=fps)
+    return VideoInput(rgb=vid, camera_intrinsics_rgb=intr, fps=info.fps)
 
 
 def plot_video_summary(

--- a/src/b3d/renderer/renderer_original.py
+++ b/src/b3d/renderer/renderer_original.py
@@ -75,9 +75,14 @@ def interpolate_fwd(self, attr, rast, faces):
     return output, (attr, rast, faces)
 
 
+# def rasterize_bwd(self, saved_tensors, diffs):
+#     pos, tri = saved_tensors
+#     return jnp.zeros_like(pos), jnp.zeros_like(tri)
+
+
 def interpolate_bwd(self, saved_tensors, diffs):
-    _attr, _rast, _faces = saved_tensors
-    return jnp.zeros_like(pos), jnp.zeros_like(tri)
+    attr, rast, faces = saved_tensors
+    return jnp.zeros_like(attr), jnp.zeros_like(rast), jnp.zeros_like(faces)
 
 
 interpolate_prim.defvjp(interpolate_fwd, interpolate_bwd)


### PR DESCRIPTION
This PR turns on the linter; we can't merge until we address the final linter bugs.

- `ruff` is enabled as a GitHub Action, so that we see errors in the PRs in github format
- `ruff` locally is added (with the same version) to `.pre-commit-config.yml`

@mirkoklukas , would you mind taking a look at the line that I pointed out in the PR?
