### PR TITLE
Set test CI timeout to 20 mins

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -15,6 +15,7 @@ env:
 jobs:
   test:
     runs-on: [self-hosted, b3d]
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
This PR sets the test CI workflow timeout to 20 minutes in order to "fail fast" if there's a problem (average runtime is expected to be ~10 minutes).