### PR TITLE
Fix a bug in truncated Laplace's logpdf compute

### DIFF
--- a/src/b3d/chisight/dynamic_object_model/likelihoods/kfold_image_kernel.py
+++ b/src/b3d/chisight/dynamic_object_model/likelihoods/kfold_image_kernel.py
@@ -82,9 +82,9 @@ class TruncatedLaplace(genjax.ExactDensity):
         assert low + uniform_window_size < high - uniform_window_size
         laplace_logpdf = tfp.distributions.Laplace(loc, scale).log_prob(obs)
         laplace_logp_below_low = tfp.distributions.Laplace(loc, scale).log_cdf(low)
-        laplace_logp_above_high = 1 - tfp.distributions.Laplace(loc, scale).log_cdf(
-            high
-        )
+        laplace_logp_above_high = tfp.distributions.Laplace(
+            loc, scale
+        ).log_survival_function(high)
         log_window_size = jnp.log(uniform_window_size)
 
         return jnp.where(


### PR DESCRIPTION
My bad. I was trying to be smart and switched to use `logcdf` instead of regular `cdf` in https://github.com/probcomp/b3d/pull/142, but I wasn't super careful when I changed the function calls, and ended up changing `1 - cdf(val)` -> `1 - log_cdf(val)`, which means totally different things. This is fixed by calling `log_survival_function(val)` instead. 

I've verified that with this fix, the two failing tests in https://github.com/probcomp/b3d/pull/142 now successfully runs.

As a side note, it's really great that we have good tests and CI to catch small bugs like this! Otherwise it could've took me ages to figure out why the model isn't working as we expected. :)