### PR TITLE
Pixel Kernels (2/2): Depth Kernels

### DIFF
--- a/src/b3d/chisight/dense/likelihoods/other_likelihoods.py
+++ b/src/b3d/chisight/dense/likelihoods/other_likelihoods.py
@@ -294,7 +294,7 @@ class PythonMixturePixelModel(genjax.ExactDensity):
     def logpdf(self, observed, probs, args):
         logprobs = []
         for i, dist in enumerate(self.dists):
-            lp = dist.logpdf(observed, *args[i])
+            lp = dist.logpdf(observed, *args[i]) + jnp.log(probs[i])
             logprobs.append(lp)
         logprobs = jnp.stack(logprobs)
         # jax.debug.print("lps = {lps}", lps=logprobs)

--- a/src/b3d/chisight/dynamic_object_model/likelihoods/kfold_image_kernel.py
+++ b/src/b3d/chisight/dynamic_object_model/likelihoods/kfold_image_kernel.py
@@ -88,15 +88,21 @@ class TruncatedLaplace(genjax.ExactDensity):
         log_window_size = jnp.log(uniform_window_size)
 
         return jnp.where(
-            jnp.logical_and(
-                low + uniform_window_size < obs, obs < high - uniform_window_size
-            ),
-            laplace_logpdf,
+            jnp.logical_or(obs < low, obs > high),
+            -jnp.inf,
             jnp.where(
-                obs < low + uniform_window_size,
-                jnp.logaddexp(laplace_logp_below_low - log_window_size, laplace_logpdf),
-                jnp.logaddexp(
-                    laplace_logp_above_high - log_window_size, laplace_logpdf
+                jnp.logical_and(
+                    low + uniform_window_size < obs, obs < high - uniform_window_size
+                ),
+                laplace_logpdf,
+                jnp.where(
+                    obs < low + uniform_window_size,
+                    jnp.logaddexp(
+                        laplace_logp_below_low - log_window_size, laplace_logpdf
+                    ),
+                    jnp.logaddexp(
+                        laplace_logp_above_high - log_window_size, laplace_logpdf
+                    ),
                 ),
             ),
         )

--- a/src/b3d/chisight/gen3d/pixel_kernels/pixel_color_kernels.py
+++ b/src/b3d/chisight/gen3d/pixel_kernels/pixel_color_kernels.py
@@ -160,7 +160,7 @@ class MixturePixelColorDistribution(PixelColorDistribution):
         **kwargs,
     ) -> FloatArray:
         return PythonMixtureDistribution(self._mixture_dists).sample(
-            key, self.get_mix_ratio(outlier_prob), [(latent_color,), ()]
+            key, self._get_mix_ratio(outlier_prob), [(), (latent_color,)]
         )
 
     def logpdf_per_channel(

--- a/src/b3d/chisight/gen3d/pixel_kernels/pixel_color_kernels.py
+++ b/src/b3d/chisight/gen3d/pixel_kernels/pixel_color_kernels.py
@@ -21,17 +21,17 @@ COLOR_MIN_VAL: float = 0.0
 COLOR_MAX_VAL: float = 1.0
 
 
-def is_unexplained(latent_color: FloatArray) -> bool:
+def is_unexplained(latent_value: FloatArray) -> bool:
     """A heuristic to check if a pixel does not have any latent point that hits
     it.
 
     Args:
-        latent_color (FloatArray): The latent color of the pixel.
+        latent_value (FloatArray): The latent color of the pixel.
 
     Returns:
         bool: True is none of the latent point hits the pixel, False otherwise.
     """
-    return jnp.any(latent_color < 0.0)
+    return jnp.any(latent_value < 0.0)
 
 
 @Pytree.dataclass
@@ -127,53 +127,51 @@ class MixturePixelColorDistribution(PixelColorDistribution):
     """A distribution that generates the color of a pixel from a mixture of a
     truncated Laplace distribution centered around the latent color (inlier
     branch) and a uniform distribution (outlier branch). The mixture is
-    controlled by the color_outlier_prob parameter. The support of the
+    controlled by the outlier_prob parameter. The support of the
     distribution is ([0, 1]^3).
     """
 
     color_scale: float
 
     @property
-    def _inlier_dist(self) -> PixelColorDistribution:
-        return TruncatedLaplacePixelColorDistribution(self.color_scale)
-
-    @property
     def _outlier_dist(self) -> PixelColorDistribution:
         return UniformPixelColorDistribution()
 
     @property
-    def _mixture_dists(self) -> tuple[PixelColorDistribution, PixelColorDistribution]:
-        return (self._inlier_dist, self._outlier_dist)
+    def _inlier_dist(self) -> PixelColorDistribution:
+        return TruncatedLaplacePixelColorDistribution(self.color_scale)
 
-    def get_mix_ratio(self, color_outlier_prob: float) -> FloatArray:
-        return jnp.array((1 - color_outlier_prob, color_outlier_prob))
+    @property
+    def _mixture_dists(self) -> tuple[PixelColorDistribution, PixelColorDistribution]:
+        return (self._outlier_dist, self._inlier_dist)
+
+    def _get_mix_ratio(self, outlier_prob: float) -> FloatArray:
+        return jnp.array((outlier_prob, 1 - outlier_prob))
 
     def sample(
         self,
         key: PRNGKey,
         latent_color: FloatArray,
-        color_outlier_prob: float,
+        outlier_prob: float,
         *args,
         **kwargs,
     ) -> FloatArray:
         return PythonMixturePixelModel(self._mixture_dists).sample(
-            key, self.get_mix_ratio(color_outlier_prob), [(latent_color,), ()]
+            key, self._get_mix_ratio(outlier_prob), [(), (latent_color,)]
         )
 
     def logpdf_per_channel(
         self,
         observed_color: FloatArray,
         latent_color: FloatArray,
-        color_outlier_prob: float,
+        outlier_prob: float,
         *args,
         **kwargs,
     ) -> FloatArray:
         # Since the mixture model class does not keep the per-channel information,
         # we have to redefine this method to allow for testing
         logprobs = []
-        for dist, prob in zip(
-            self._mixture_dists, self.get_mix_ratio(color_outlier_prob)
-        ):
+        for dist, prob in zip(self._mixture_dists, self._get_mix_ratio(outlier_prob)):
             logprobs.append(
                 dist.logpdf_per_channel(observed_color, latent_color) + jnp.log(prob)
             )
@@ -190,8 +188,8 @@ class FullPixelColorDistribution(PixelColorDistribution):
         color ~ uniform(0, 1)
     else:
         color ~ mixture(
-            [truncated_laplace(latent_color; color_scale), uniform(0, 1)],
-            [1 - color_outlier_prob, color_outlier_prob]
+            [uniform(0, 1), truncated_laplace(latent_color; color_scale)],
+            [outlier_prob, 1 - outlier_prob]
         )
     """
 
@@ -209,40 +207,34 @@ class FullPixelColorDistribution(PixelColorDistribution):
         self,
         key: PRNGKey,
         latent_color: FloatArray,
-        color_outlier_prob: FloatArray,
+        outlier_prob: FloatArray,
         *args,
         **kwargs,
     ) -> FloatArray:
-        # Check if any of the latent point hits the current pixel
-        is_explained = ~is_unexplained(latent_color)
-
         return jax.lax.cond(
-            is_explained,
-            self._color_from_latent.sample,  # if pixel is being hit by a latent point
+            is_unexplained(latent_color),
             self._unexplained_color.sample,  # if no point hits current pixel
+            self._color_from_latent.sample,  # if pixel is being hit by a latent point
             # sample args
             key,
             latent_color,
-            color_outlier_prob,
+            outlier_prob,
         )
 
     def logpdf_per_channel(
         self,
         observed_color: FloatArray,
         latent_color: FloatArray,
-        color_outlier_prob: float,
+        outlier_prob: float,
         *args,
         **kwargs,
     ) -> FloatArray:
-        # Check if any of the latent point hits the current pixel
-        is_explained = ~is_unexplained(latent_color)
-
         return jax.lax.cond(
-            is_explained,
-            self._color_from_latent.logpdf_per_channel,  # if pixel is being hit by a latent point
+            is_unexplained(latent_color),
             self._unexplained_color.logpdf_per_channel,  # if no point hits current pixel
+            self._color_from_latent.logpdf_per_channel,  # if pixel is being hit by a latent point
             # logpdf args
             observed_color,
             latent_color,
-            color_outlier_prob,
+            outlier_prob,
         )

--- a/src/b3d/chisight/gen3d/pixel_kernels/pixel_depth_kernels.py
+++ b/src/b3d/chisight/gen3d/pixel_kernels/pixel_depth_kernels.py
@@ -1,0 +1,312 @@
+from abc import abstractmethod
+from typing import TYPE_CHECKING, Any
+
+import genjax
+import jax
+import jax.numpy as jnp
+from genjax import Pytree
+from genjax.typing import FloatArray, PRNGKey
+from tensorflow_probability.substrates import jax as tfp
+
+from b3d.chisight.dense.likelihoods.other_likelihoods import PythonMixturePixelModel
+from b3d.chisight.dynamic_object_model.likelihoods.kfold_image_kernel import (
+    _FIXED_DEPTH_UNIFORM_WINDOW,
+    truncated_laplace,
+)
+from b3d.chisight.gen3d.pixel_kernels.pixel_color_kernels import is_unexplained
+
+if TYPE_CHECKING:
+    import tensorflow_probability.python.distributions.distribution as dist
+
+DEPTH_NONRETURN_VAL = 0.0
+UNEXPLAINED_DEPTH_NONRETURN_PROB = 0.02
+
+
+@Pytree.dataclass
+class PixelDepthDistribution(genjax.ExactDensity):
+    """An abstract class that defines the common interface for pixel depth kernels."""
+
+    @abstractmethod
+    def sample(self, key: PRNGKey, latent_depth: float, *args, **kwargs) -> float:
+        raise NotImplementedError
+
+    @abstractmethod
+    def logpdf(
+        self, observed_depth: float, latent_depth: float, *args, **kwargs
+    ) -> float:
+        raise NotImplementedError
+
+
+@Pytree.dataclass
+class TruncatedLaplacePixelDepthDistribution(PixelDepthDistribution):
+    """A distribution that generates the depth of a pixel from a truncated
+    Laplace distribution centered around the latent depth, with the spread
+    controlled by depth_scale. The support of the distribution is [near, far].
+    """
+
+    near: float = Pytree.static()
+    far: float = Pytree.static()
+    depth_scale: float
+    # the uniform window is used to wrapped the truncated laplace distribution
+    # to ensure that the depth generated is within the range of [near, far]
+    uniform_window_size: float = Pytree.static(default=_FIXED_DEPTH_UNIFORM_WINDOW)
+
+    def sample(self, key: PRNGKey, latent_depth: float, *args, **kwargs) -> float:
+        return truncated_laplace.sample(
+            key,
+            latent_depth,
+            self.depth_scale,
+            self.near,
+            self.far,
+            self.uniform_window_size,
+        )
+
+    def logpdf(
+        self, observed_depth: float, latent_depth: float, *args, **kwargs
+    ) -> float:
+        return truncated_laplace.logpdf(
+            observed_depth,
+            latent_depth,
+            self.depth_scale,
+            self.near,
+            self.far,
+            self.uniform_window_size,
+        )
+
+
+@Pytree.dataclass
+class UniformPixelDepthDistribution(PixelDepthDistribution):
+    """A distribution that generates the depth of a pixel from a uniform from
+    [near, far]."""
+
+    near: float = Pytree.static()
+    far: float = Pytree.static()
+
+    @property
+    def _base_dist(self) -> "dist.Distribution":
+        return tfp.distributions.Uniform(self.near, self.far)
+
+    def sample(self, key: PRNGKey, *args, **kwargs) -> float:
+        return self._base_dist.sample(seed=key)
+
+    def logpdf(self, observed_depth: float, *args, **kwargs) -> float:
+        return self._base_dist.log_prob(observed_depth)
+
+
+@Pytree.dataclass
+class DeltaDistribution(genjax.ExactDensity):
+    """
+    Degenerate discrete distribution (a single point). It assigns probability one
+    to the single element in its support.
+    """
+
+    value: Any
+
+    def sample(self, key: PRNGKey, *args, **kwargs) -> Any:
+        return self.value
+
+    def logpdf(self, sampled_val: Any, *args, **kwargs) -> float:
+        return jnp.log(sampled_val == self.value)
+
+
+@Pytree.dataclass
+class MixturePixelDepthDistribution(PixelDepthDistribution):
+    """A distribution that generates the depth of a pixel from
+    mixture(
+        [delta(-1), uniform(near, far), laplace(latent_depth; depth_scale)],
+        [depth_nonreturn_prob, (1 - depth_nonreturn_prob) * outlier_prob, remaining_prob]
+    )
+
+    The support of the distribution is [near, far] ∪ { "nonreturn" }.
+    """
+
+    near: float = Pytree.static()
+    far: float = Pytree.static()
+    depth_scale: float
+
+    @property
+    def _nonreturn_dist(self) -> PixelDepthDistribution:
+        return DeltaDistribution(DEPTH_NONRETURN_VAL)
+
+    @property
+    def _outlier_dist(self) -> PixelDepthDistribution:
+        return UniformPixelDepthDistribution(self.near, self.far)
+
+    @property
+    def _inlier_dist(self) -> PixelDepthDistribution:
+        return TruncatedLaplacePixelDepthDistribution(
+            self.near, self.far, self.depth_scale
+        )
+
+    @property
+    def _mixture_dist(self) -> PythonMixturePixelModel:
+        return PythonMixturePixelModel(
+            (self._nonreturn_dist, self._outlier_dist, self._inlier_dist)
+        )
+
+    def _get_mix_ratio(
+        self, depth_nonreturn_prob: float, outlier_prob: float
+    ) -> FloatArray:
+        return jnp.array(
+            (
+                depth_nonreturn_prob,
+                (1 - depth_nonreturn_prob) * outlier_prob,
+                (1 - depth_nonreturn_prob) * (1 - outlier_prob),
+            )
+        )
+
+    def sample(
+        self,
+        key: PRNGKey,
+        latent_depth: float,
+        depth_nonreturn_prob: float,
+        outlier_prob: float,
+        *args,
+        **kwargs,
+    ) -> float:
+        return self._mixture_dist.sample(
+            key,
+            self._get_mix_ratio(depth_nonreturn_prob, outlier_prob),
+            [(), (), (latent_depth,)],
+        )
+
+    def logpdf(
+        self,
+        observed_depth: float,
+        latent_depth: float,
+        depth_nonreturn_prob: float,
+        outlier_prob: float,
+        *args,
+        **kwargs,
+    ) -> float:
+        return self._mixture_dist.logpdf(
+            observed_depth,
+            self._get_mix_ratio(depth_nonreturn_prob, outlier_prob),
+            [(), (), (latent_depth,)],
+        )
+
+
+@Pytree.dataclass
+class UnexplainedPixelDepthDistribution(PixelDepthDistribution):
+    """A distribution that generates the depth of a pixel from
+    mixture(
+        [delta(-1), uniform(near, far)],
+        [unexplained_depth_nonreturn_prob, 1 - unexplained_depth_nonreturn_prob]
+    ),
+    for pixels that are not explained by the latent points.
+
+    The support of the distribution is [near, far] ∪ { "nonreturn" }.
+    """
+
+    near: float = Pytree.static()
+    far: float = Pytree.static()
+    unexplained_depth_nonreturn_prob: float = Pytree.static(
+        default=UNEXPLAINED_DEPTH_NONRETURN_PROB
+    )
+
+    @property
+    def _nonreturn_dist(self) -> PixelDepthDistribution:
+        return DeltaDistribution(DEPTH_NONRETURN_VAL)
+
+    @property
+    def _uniform_dist(self) -> PixelDepthDistribution:
+        return UniformPixelDepthDistribution(self.near, self.far)
+
+    @property
+    def _mixture_dist(self) -> PythonMixturePixelModel:
+        return PythonMixturePixelModel((self._nonreturn_dist, self._uniform_dist))
+
+    @property
+    def _mix_ratio(self) -> FloatArray:
+        return jnp.array(
+            (
+                self.unexplained_depth_nonreturn_prob,
+                1 - self.unexplained_depth_nonreturn_prob,
+            )
+        )
+
+    def sample(
+        self,
+        key: PRNGKey,
+        *args,
+        **kwargs,
+    ) -> float:
+        return self._mixture_dist.sample(key, self._mix_ratio, [(), ()])
+
+    def logpdf(
+        self,
+        observed_depth: float,
+        *args,
+        **kwargs,
+    ) -> float:
+        return self._mixture_dist.logpdf(observed_depth, self._mix_ratio, [(), ()])
+
+
+@Pytree.dataclass
+class FullPixelDepthDistribution(PixelDepthDistribution):
+    """A distribution that generates the depth of the pixel according to the
+    following rule:
+
+    if no latent point hits the pixel:
+        depth ~ mixture(
+            [delta(-1), uniform(near, far)],
+            [unexplained_depth_nonreturn_prob, 1 - unexplained_depth_nonreturn_prob]
+        )
+    else:
+        mixture(
+            [delta(-1), uniform(near, far), laplace(latent_depth; depth_scale)],
+            [depth_nonreturn_prob, (1 - depth_nonreturn_prob) * outlier_prob, remaining_prob]
+        )
+    """
+
+    near: float = Pytree.static()
+    far: float = Pytree.static()
+    depth_scale: float
+
+    @property
+    def _depth_from_latent(self) -> PixelDepthDistribution:
+        return MixturePixelDepthDistribution(self.near, self.far, self.depth_scale)
+
+    @property
+    def _unexplained_depth(self) -> PixelDepthDistribution:
+        return UnexplainedPixelDepthDistribution(self.near, self.far)
+
+    def sample(
+        self,
+        key: PRNGKey,
+        latent_depth: FloatArray,
+        depth_nonreturn_prob: float,
+        outlier_prob: FloatArray,
+        *args,
+        **kwargs,
+    ) -> FloatArray:
+        return jax.lax.cond(
+            is_unexplained(latent_depth),
+            self._unexplained_depth.sample,  # if no point hits current pixel
+            self._depth_from_latent.sample,  # if pixel is being hit by a latent point
+            # sample args
+            key,
+            latent_depth,
+            depth_nonreturn_prob,
+            outlier_prob,
+        )
+
+    def logpdf(
+        self,
+        observed_depth: FloatArray,
+        latent_depth: FloatArray,
+        depth_nonreturn_prob: float,
+        outlier_prob: float,
+        *args,
+        **kwargs,
+    ) -> FloatArray:
+        return jax.lax.cond(
+            is_unexplained(latent_depth),
+            self._unexplained_depth.logpdf,  # if no point hits current pixel
+            self._depth_from_latent.logpdf,  # if pixel is being hit by a latent point
+            # logpdf args
+            observed_depth,
+            latent_depth,
+            depth_nonreturn_prob,
+            outlier_prob,
+        )

--- a/src/b3d/chisight/gen3d/pixel_kernels/pixel_depth_kernels.py
+++ b/src/b3d/chisight/gen3d/pixel_kernels/pixel_depth_kernels.py
@@ -8,12 +8,12 @@ from genjax import Pytree
 from genjax.typing import FloatArray, PRNGKey
 from tensorflow_probability.substrates import jax as tfp
 
-from b3d.chisight.dense.likelihoods.other_likelihoods import PythonMixturePixelModel
-from b3d.chisight.dynamic_object_model.likelihoods.kfold_image_kernel import (
+from b3d.chisight.gen3d.pixel_kernels.pixel_color_kernels import is_unexplained
+from b3d.modeling_utils import (
     _FIXED_DEPTH_UNIFORM_WINDOW,
+    PythonMixtureDistribution,
     truncated_laplace,
 )
-from b3d.chisight.gen3d.pixel_kernels.pixel_color_kernels import is_unexplained
 
 if TYPE_CHECKING:
     import tensorflow_probability.python.distributions.distribution as dist
@@ -139,8 +139,8 @@ class MixturePixelDepthDistribution(PixelDepthDistribution):
         )
 
     @property
-    def _mixture_dist(self) -> PythonMixturePixelModel:
-        return PythonMixturePixelModel(
+    def _mixture_dist(self) -> PythonMixtureDistribution:
+        return PythonMixtureDistribution(
             (self._nonreturn_dist, self._outlier_dist, self._inlier_dist)
         )
 
@@ -213,8 +213,8 @@ class UnexplainedPixelDepthDistribution(PixelDepthDistribution):
         return UniformPixelDepthDistribution(self.near, self.far)
 
     @property
-    def _mixture_dist(self) -> PythonMixturePixelModel:
-        return PythonMixturePixelModel((self._nonreturn_dist, self._uniform_dist))
+    def _mixture_dist(self) -> PythonMixtureDistribution:
+        return PythonMixtureDistribution((self._nonreturn_dist, self._uniform_dist))
 
     @property
     def _mix_ratio(self) -> FloatArray:

--- a/src/b3d/modeling_utils.py
+++ b/src/b3d/modeling_utils.py
@@ -156,15 +156,21 @@ class TruncatedLaplace(genjax.ExactDensity):
         log_window_size = jnp.log(uniform_window_size)
 
         return jnp.where(
-            jnp.logical_and(
-                low + uniform_window_size < obs, obs < high - uniform_window_size
-            ),
-            laplace_logpdf,
+            jnp.logical_or(obs < low, obs > high),
+            -jnp.inf,
             jnp.where(
-                obs < low + uniform_window_size,
-                jnp.logaddexp(laplace_logp_below_low - log_window_size, laplace_logpdf),
-                jnp.logaddexp(
-                    laplace_logp_above_high - log_window_size, laplace_logpdf
+                jnp.logical_and(
+                    low + uniform_window_size < obs, obs < high - uniform_window_size
+                ),
+                laplace_logpdf,
+                jnp.where(
+                    obs < low + uniform_window_size,
+                    jnp.logaddexp(
+                        laplace_logp_below_low - log_window_size, laplace_logpdf
+                    ),
+                    jnp.logaddexp(
+                        laplace_logp_above_high - log_window_size, laplace_logpdf
+                    ),
                 ),
             ),
         )
@@ -173,6 +179,7 @@ class TruncatedLaplace(genjax.ExactDensity):
 truncated_laplace = TruncatedLaplace()
 
 _FIXED_COLOR_UNIFORM_WINDOW = 1 / 255
+_FIXED_DEPTH_UNIFORM_WINDOW = 0.01
 
 
 @Pytree.dataclass

--- a/tests/gen3d/test_pixel_color_kernels.py
+++ b/tests/gen3d/test_pixel_color_kernels.py
@@ -36,8 +36,8 @@ def generate_color_grid(n_grid_steps: int):
 sample_kernels_to_test = [
     (UniformPixelColorDistribution(), ()),
     (TruncatedLaplacePixelColorDistribution(0.1), ()),
-    (MixturePixelColorDistribution(0.3), (0.5,)),  # color_outlier_prob
-    (FullPixelColorDistribution(0.5), (0.3,)),  # color_outlier_prob
+    (MixturePixelColorDistribution(0.3), (0.5,)),  # outlier_prob
+    (FullPixelColorDistribution(0.5), (0.3,)),  # outlier_prob
 ]
 
 

--- a/tests/gen3d/test_pixel_depth_kernels.py
+++ b/tests/gen3d/test_pixel_depth_kernels.py
@@ -1,0 +1,106 @@
+import jax
+import jax.numpy as jnp
+import pytest
+from b3d.chisight.gen3d.pixel_kernels.pixel_depth_kernels import (
+    DEPTH_NONRETURN_VAL,
+    UNEXPLAINED_DEPTH_NONRETURN_PROB,
+    FullPixelDepthDistribution,
+    MixturePixelDepthDistribution,
+    TruncatedLaplacePixelDepthDistribution,
+    UnexplainedPixelDepthDistribution,
+    UniformPixelDepthDistribution,
+)
+
+near = 0.01
+far = 20.0
+
+# each kernel specs is a tuple of (kernel, additional_args)
+sample_kernels_to_test = [
+    (UniformPixelDepthDistribution(near, far), ()),
+    (TruncatedLaplacePixelDepthDistribution(near, far, 0.25), ()),
+    (UnexplainedPixelDepthDistribution(near, far), ()),
+    (
+        MixturePixelDepthDistribution(near, far, 0.15),
+        (
+            0.23,  # depth_nonreturn_prob
+            0.5,  # outlier_prob
+        ),
+    ),
+    (
+        FullPixelDepthDistribution(near, far, 0.5),
+        (
+            0.1,  # depth_nonreturn_prob
+            0.3,  # outlier_prob
+        ),
+    ),
+]
+
+
+@pytest.mark.parametrize("latent_depth", [0.2, 10.0])
+@pytest.mark.parametrize("kernel_spec", sample_kernels_to_test)
+def test_logpdf_sum_to_1(kernel_spec, latent_depth: float):
+    kernel, additional_args = kernel_spec
+    # compute the mass in [near, far]
+    n_grid_steps = 10000000
+    depth_grid = jnp.linspace(near, far, n_grid_steps)
+    logpdfs = jax.vmap(
+        lambda depth: kernel.logpdf(depth, latent_depth, *additional_args)
+    )(depth_grid)
+    log_pmass = (
+        jax.scipy.special.logsumexp(logpdfs)
+        + jnp.log(far - near)
+        - jnp.log(n_grid_steps)
+    )
+    # compute the mass in { "nonreturn" }
+    log_nonreturn_mass = kernel.logpdf(
+        DEPTH_NONRETURN_VAL, latent_depth, *additional_args
+    )
+    log_pmass = jnp.logaddexp(log_pmass, log_nonreturn_mass)
+
+    assert jnp.isclose(log_pmass, 0.0, atol=1e-3)
+
+
+@pytest.mark.parametrize("latent_depth", [0.2, 10.0, 19.9])
+@pytest.mark.parametrize("kernel_spec", sample_kernels_to_test)
+def test_sample_in_valid_depth_range(kernel_spec, latent_depth):
+    kernel, additional_args = kernel_spec
+    num_samples = 1000
+    keys = jax.random.split(jax.random.PRNGKey(0), num_samples)
+    depths = jax.vmap(lambda key: kernel.sample(key, latent_depth, *additional_args))(
+        keys
+    )
+    assert depths.shape == (num_samples,)
+    assert jnp.all((depths > near) | (depths == DEPTH_NONRETURN_VAL))
+    assert jnp.all((depths < far) | (depths == DEPTH_NONRETURN_VAL))
+
+
+def test_relative_logpdf():
+    kernel = FullPixelDepthDistribution(near, far, 0.1)
+
+    # case 1: depth is missing in observation (nonreturn)
+    obs_depth = DEPTH_NONRETURN_VAL
+    latent_depth = DEPTH_NONRETURN_VAL
+    depth_nonreturn_prob = 0.2
+    logpdf_1 = kernel.logpdf(obs_depth, latent_depth, depth_nonreturn_prob, 0.8)
+    assert logpdf_1 == jnp.log(depth_nonreturn_prob)
+
+    latent_depth = -1.0  # no depth information from latent
+    logpdf_2 = kernel.logpdf(obs_depth, latent_depth, depth_nonreturn_prob, 0.8)
+    # nonreturn obs cannot be generates from latent that is not nonreturn
+    assert logpdf_2 == jnp.log(UNEXPLAINED_DEPTH_NONRETURN_PROB)
+
+    # case 2: valid depth is observed, but latent depth is far from the observed depth
+    obs_depth = 10.0
+    latent_depth = 0.01
+    logpdf_3 = kernel.logpdf(obs_depth, latent_depth, depth_nonreturn_prob, 0.9)
+    logpdf_4 = kernel.logpdf(obs_depth, latent_depth, depth_nonreturn_prob, 0.1)
+    # the pixel should be more likely to be an outlier
+    assert logpdf_3 > logpdf_4
+
+    # case 3: valid depth is observed, but latent depth is close from the observed depth
+    obs_depth = 6.0
+    latent_depth = 6.01
+    logpdf_5 = kernel.logpdf(obs_depth, latent_depth, depth_nonreturn_prob, 0.9)
+    logpdf_6 = kernel.logpdf(obs_depth, latent_depth, depth_nonreturn_prob, 0.1)
+    # the pixel should be more likely to be an inliner
+    assert logpdf_5 < logpdf_6


### PR DESCRIPTION
This PR implements the second piece of the new image kernel: the per-pixel kernels that generates the observed depth given the latent (when available), as outlined [in this Notion card](https://www.notion.so/chi-mit/Sep-9-Track-2-Image-Kernel-Deliverables-70f1490053564db7b4ab3197447f7aaa?pvs=4). The organization of the kernels roughly follows the same structure as the previous PR: https://github.com/probcomp/b3d/pull/147 

## Test Plan

I've added some unit tests to make sure that the kernels roughly have the behaviors that we expected:

```bash
pytest pytest tests/gen3d/test_pixel_depth_kernels.py
```