### PR TITLE
Pixel Kernels (3/2): RGBD Kernels

### DIFF
--- a/src/b3d/chisight/gen3d/pixel_kernels/pixel_rgbd_kernels.py
+++ b/src/b3d/chisight/gen3d/pixel_kernels/pixel_rgbd_kernels.py
@@ -1,0 +1,37 @@
+import genjax
+import jax
+import jax.numpy as jnp
+from genjax import Pytree
+from genjax.typing import FloatArray, PRNGKey
+
+from b3d.chisight.gen3d.pixel_kernels.pixel_color_kernels import PixelColorDistribution
+from b3d.chisight.gen3d.pixel_kernels.pixel_depth_kernels import PixelDepthDistribution
+
+
+@Pytree.dataclass
+class PixelRGBDDistribution(genjax.ExactDensity):
+    color_kernel: PixelColorDistribution
+    depth_kernel: PixelDepthDistribution
+
+    def sample(
+        self, key: PRNGKey, latent_rgbd: FloatArray, *args, **kwargs
+    ) -> FloatArray:
+        keys = jax.random.split(key, 2)
+        observed_color = self.color_kernel.sample(
+            keys[0], latent_rgbd[:3], *args, **kwargs
+        )
+        observed_depth = self.depth_kernel.sample(
+            keys[1], latent_rgbd[3], *args, **kwargs
+        )
+        return jnp.append(observed_color, observed_depth)
+
+    def logpdf(
+        self, observed_rgbd: FloatArray, latent_rgbd: FloatArray, *args, **kwargs
+    ) -> float:
+        color_logpdf = self.color_kernel.logpdf(
+            observed_rgbd[:3], latent_rgbd[:3], *args, **kwargs
+        )
+        depth_logpdf = self.depth_kernel.logpdf(
+            observed_rgbd[3], latent_rgbd[3], *args, **kwargs
+        )
+        return color_logpdf + depth_logpdf

--- a/tests/gen3d/test_pixel_color_kernels.py
+++ b/tests/gen3d/test_pixel_color_kernels.py
@@ -36,8 +36,8 @@ def generate_color_grid(n_grid_steps: int):
 sample_kernels_to_test = [
     (UniformPixelColorDistribution(), ()),
     (TruncatedLaplacePixelColorDistribution(0.1), ()),
-    (MixturePixelColorDistribution(0.3), (0.5,)),  # outlier_prob
-    (FullPixelColorDistribution(0.5), (0.3,)),  # outlier_prob
+    (MixturePixelColorDistribution(0.3), (0.5,)),  # occluded_prob
+    (FullPixelColorDistribution(0.5), (0.3,)),  # occluded_prob
 ]
 
 
@@ -80,7 +80,7 @@ def test_relative_logpdf():
     latent_color = -jnp.ones(3)  # use -1 to denote invalid pixel
     logpdf_1 = kernel.logpdf(obs_color, latent_color, 0.2)
     logpdf_2 = kernel.logpdf(obs_color, latent_color, 0.8)
-    # the logpdf should be the same because the outlier probability is not used
+    # the logpdf should be the same because the occluded probability is not used
     # in the case when no color hit the pixel
     assert jnp.allclose(logpdf_1, logpdf_2)
 
@@ -88,7 +88,7 @@ def test_relative_logpdf():
     latent_color = jnp.array([1.0, 0.5, 0.0])
     logpdf_3 = kernel.logpdf(obs_color, latent_color, 0.2)
     logpdf_4 = kernel.logpdf(obs_color, latent_color, 0.8)
-    # the pixel should be more likely to be an outlier
+    # the pixel should be more likely to be an occluded
     assert logpdf_3 < logpdf_4
 
     # case 3: a color hit the pixel, and the color is close to the observed color

--- a/tests/gen3d/test_pixel_depth_kernels.py
+++ b/tests/gen3d/test_pixel_depth_kernels.py
@@ -22,15 +22,15 @@ sample_kernels_to_test = [
     (
         MixturePixelDepthDistribution(near, far, 0.15),
         (
+            0.5,  # occluded_prob
             0.23,  # depth_nonreturn_prob
-            0.5,  # outlier_prob
         ),
     ),
     (
         FullPixelDepthDistribution(near, far, 0.5),
         (
+            0.3,  # occluded_prob
             0.1,  # depth_nonreturn_prob
-            0.3,  # outlier_prob
         ),
     ),
 ]
@@ -81,26 +81,26 @@ def test_relative_logpdf():
     obs_depth = DEPTH_NONRETURN_VAL
     latent_depth = DEPTH_NONRETURN_VAL
     depth_nonreturn_prob = 0.2
-    logpdf_1 = kernel.logpdf(obs_depth, latent_depth, depth_nonreturn_prob, 0.8)
+    logpdf_1 = kernel.logpdf(obs_depth, latent_depth, 0.8, depth_nonreturn_prob)
     assert logpdf_1 == jnp.log(depth_nonreturn_prob)
 
     latent_depth = -1.0  # no depth information from latent
-    logpdf_2 = kernel.logpdf(obs_depth, latent_depth, depth_nonreturn_prob, 0.8)
+    logpdf_2 = kernel.logpdf(obs_depth, latent_depth, 0.8, depth_nonreturn_prob)
     # nonreturn obs cannot be generates from latent that is not nonreturn
     assert logpdf_2 == jnp.log(UNEXPLAINED_DEPTH_NONRETURN_PROB)
 
     # case 2: valid depth is observed, but latent depth is far from the observed depth
     obs_depth = 10.0
     latent_depth = 0.01
-    logpdf_3 = kernel.logpdf(obs_depth, latent_depth, depth_nonreturn_prob, 0.9)
-    logpdf_4 = kernel.logpdf(obs_depth, latent_depth, depth_nonreturn_prob, 0.1)
-    # the pixel should be more likely to be an outlier
+    logpdf_3 = kernel.logpdf(obs_depth, latent_depth, 0.9, depth_nonreturn_prob)
+    logpdf_4 = kernel.logpdf(obs_depth, latent_depth, 0.1, depth_nonreturn_prob)
+    # the pixel should be more likely to be an occluded
     assert logpdf_3 > logpdf_4
 
     # case 3: valid depth is observed, but latent depth is close from the observed depth
     obs_depth = 6.0
     latent_depth = 6.01
-    logpdf_5 = kernel.logpdf(obs_depth, latent_depth, depth_nonreturn_prob, 0.9)
-    logpdf_6 = kernel.logpdf(obs_depth, latent_depth, depth_nonreturn_prob, 0.1)
+    logpdf_5 = kernel.logpdf(obs_depth, latent_depth, 0.9, depth_nonreturn_prob)
+    logpdf_6 = kernel.logpdf(obs_depth, latent_depth, 0.1, depth_nonreturn_prob)
     # the pixel should be more likely to be an inliner
     assert logpdf_5 < logpdf_6

--- a/tests/gen3d/test_pixel_rgbd_kernels.py
+++ b/tests/gen3d/test_pixel_rgbd_kernels.py
@@ -1,0 +1,92 @@
+import jax
+import jax.numpy as jnp
+import pytest
+from b3d.chisight.gen3d.pixel_kernels.pixel_color_kernels import (
+    FullPixelColorDistribution,
+)
+from b3d.chisight.gen3d.pixel_kernels.pixel_depth_kernels import (
+    DEPTH_NONRETURN_VAL,
+    FullPixelDepthDistribution,
+)
+from b3d.chisight.gen3d.pixel_kernels.pixel_rgbd_kernels import PixelRGBDDistribution
+
+near = 0.01
+far = 20.0
+
+sample_kernels_to_test = [
+    (
+        PixelRGBDDistribution(
+            FullPixelColorDistribution(0.01),
+            FullPixelDepthDistribution(near, far, 0.01),
+        ),
+        (
+            0.3,  # occluded_prob
+            0.1,  # depth_nonreturn_prob
+        ),
+    )
+]
+
+
+@pytest.mark.parametrize(
+    "latent_rgbd",
+    [
+        jnp.array([0.25, 0.87, 0.31, 10.0]),
+        jnp.array([0.0, 0.0, 0.0, 0.02]),
+        jnp.array([1.0, 1.0, 1.0, 19.9]),
+    ],
+)
+@pytest.mark.parametrize("kernel_spec", sample_kernels_to_test)
+def test_sample_in_valid_rgbd_range(kernel_spec, latent_rgbd):
+    kernel, additional_args = kernel_spec
+    num_samples = 1000
+    keys = jax.random.split(jax.random.PRNGKey(0), num_samples)
+    rgbds = jax.vmap(lambda key: kernel.sample(key, latent_rgbd, *additional_args))(
+        keys
+    )
+    assert rgbds.shape == (num_samples, 4)
+    assert jnp.all(rgbds[..., :3] > 0)
+    assert jnp.all(rgbds[..., :3] < 1)
+    assert jnp.all((rgbds[..., 3] > near) | (rgbds[..., 3] == DEPTH_NONRETURN_VAL))
+    assert jnp.all((rgbds[..., 3] < far) | (rgbds[..., 3] == DEPTH_NONRETURN_VAL))
+
+
+@pytest.mark.parametrize("kernel_spec", sample_kernels_to_test)
+def test_relative_logpdf(kernel_spec):
+    kernel, _ = kernel_spec
+    obs_rgbd = jnp.array([0.0, 0.0, 1.0, 0.02])  # a blue pixel
+
+    # case 1: no vertex hit the pixel
+    latent_rgbd = -jnp.ones(4)  # use -1 to denote invalid pixel
+    logpdf_1 = kernel.logpdf(
+        obs_rgbd, latent_rgbd, occluded_prob=0.2, depth_nonreturn_prob=0.1
+    )
+    logpdf_2 = kernel.logpdf(
+        obs_rgbd, latent_rgbd, occluded_prob=0.8, depth_nonreturn_prob=0.1
+    )
+    # the logpdf should be the same because the occluded probability is not used
+    # in the case when no vertex hit the pixel
+    assert jnp.allclose(logpdf_1, logpdf_2)
+
+    # case 2: a vertex hit the pixel, but the rgbd is not close to the observed rgbd
+    latent_rgbd = jnp.array([1.0, 0.5, 0.0, 12.0])
+    logpdf_3 = kernel.logpdf(
+        obs_rgbd, latent_rgbd, occluded_prob=0.2, depth_nonreturn_prob=0.1
+    )
+    logpdf_4 = kernel.logpdf(
+        obs_rgbd, latent_rgbd, occluded_prob=0.8, depth_nonreturn_prob=0.1
+    )
+    # the pixel should be more likely to be an occluded
+    assert logpdf_3 < logpdf_4
+
+    # case 3: a vertex hit the pixel, and the rgbd is close to the observed rgbd
+    latent_rgbd = jnp.array([0.0, 0.0, 0.95, 0.022])
+    logpdf_5 = kernel.logpdf(
+        obs_rgbd, latent_rgbd, occluded_prob=0.2, depth_nonreturn_prob=0.1
+    )
+    logpdf_6 = kernel.logpdf(
+        obs_rgbd, latent_rgbd, occluded_prob=0.8, depth_nonreturn_prob=0.1
+    )
+    # the pixel should be more likely to be an inlier
+    assert logpdf_5 > logpdf_6
+    # the score of the pixel should be higher when the rgbd is closer
+    assert logpdf_5 > logpdf_3


### PR DESCRIPTION
While working on the image kernels, I realized that it might be useful to have a unified class that sample the RGBD values jointly, so I'm introducing this utility class that takes in an color kernel (from https://github.com/probcomp/b3d/pull/147) and a depth kernel (from https://github.com/probcomp/b3d/pull/149) to create an RGBD kernel, which supports sample and logpdf computation.

This is a general class that's agnostic of the type of RGB and depth kernels -- it'll pass in the arguments it receives to _both_ of the kernels during `sample` and `logpdf` call. Since both color and depth kernels have `*args, **kwargs` as part of their function signature, they should simply ignore additional arguments that's not relevant to them.

(I also just realized that I was referring to these classes as "kernels" but the actual class names are `*Distributions`... maybe I should fix these in a future PR.)

I'm submitting this PR to `main` for now. Once I'm wrapping up my local changes, I'm going to work on resolving merge conflicts with `gen3d`.

## Test Plan

Similar to the previous PRs, I've added some unit tests to make sure that the kernels roughly have the behaviors that we expected:

```bash
pytest tests/gen3d/test_pixel_rgbd_kernels.py
```