### PR TITLE
PixelRGBDDistribution: Additional tests on invalid RGBD values

### DIFF
--- a/src/b3d/chisight/gen3d/inference_moves.py
+++ b/src/b3d/chisight/gen3d/inference_moves.py
@@ -265,7 +265,7 @@ def propose_vertex_color_and_visibility_prob(
             .logpdf(
                 observed_rgbd=observed_rgbd_for_this_vertex,
                 latent_rgbd=jnp.append(rgb, latent_depth),
-                rgb_scale=new_state["color_scale"],
+                color_scale=new_state["color_scale"],
                 depth_scale=new_state["depth_scale"],
                 visibility_prob=visprob,
                 depth_nonreturn_prob=new_state["depth_nonreturn_prob"][vertex_index],

--- a/src/b3d/chisight/gen3d/pixel_kernels/__init__.py
+++ b/src/b3d/chisight/gen3d/pixel_kernels/__init__.py
@@ -2,8 +2,10 @@ from b3d.chisight.gen3d.pixel_kernels.pixel_color_kernels import (
     FullPixelColorDistribution,
     MixturePixelColorDistribution,
     PixelColorDistribution,
+    is_unexplained,
 )
 from b3d.chisight.gen3d.pixel_kernels.pixel_depth_kernels import (
+    DEPTH_NONRETURN_VAL,
     FullPixelDepthDistribution,
     MixturePixelDepthDistribution,
     PixelDepthDistribution,
@@ -12,6 +14,8 @@ from b3d.chisight.gen3d.pixel_kernels.pixel_depth_kernels import (
 from b3d.chisight.gen3d.pixel_kernels.pixel_rgbd_kernels import PixelRGBDDistribution
 
 __all__ = [
+    "is_unexplained",
+    "DEPTH_NONRETURN_VAL",
     "FullPixelColorDistribution",
     "FullPixelDepthDistribution",
     "MixturePixelColorDistribution",

--- a/src/b3d/chisight/gen3d/projection.py
+++ b/src/b3d/chisight/gen3d/projection.py
@@ -94,11 +94,7 @@ class PixelsPointsAssociation(Pytree):
         by indexing into the given image.
         Vertices that don't hit a pixel will have a value of (-1, -1, -1, -1).
         """
-        unfiltered = rgbd_image[self.x, self.y]
-        invalid_indices = jnp.logical_or(self.x == INVALID_IDX, self.y == INVALID_IDX)
-        return jnp.where(
-            invalid_indices[:, None], -jnp.ones_like(unfiltered), unfiltered
-        )
+        return rgbd_image.at[self.x, self.y].get(mode="drop", fill_value=-1.0)
 
     def get_point_depths(self, rgbd_image: FloatArray) -> FloatArray:
         """

--- a/src/b3d/chisight/gen3d/transition_kernels.py
+++ b/src/b3d/chisight/gen3d/transition_kernels.py
@@ -224,7 +224,7 @@ class LaplaceColorDriftKernel(DriftKernel):
     This is a thin wrapper around the truncated_color_laplace distribution to
     provide a consistent interface with other drift kernels.
 
-    Support: [0.0, 1.0]
+    Support: [0.0, 1.0]^3
     """
 
     scale: float = Pytree.static()
@@ -244,16 +244,13 @@ class LaplaceColorDriftKernel(DriftKernel):
 @Pytree.dataclass
 class LaplaceNotTruncatedColorDriftKernel(DriftKernel):
     """A drift kernel that samples the 3 channels of the color from a specialized
-    truncated Laplace distribution, centered at the previous color. Values outside
-    of the bounds will be resampled from a small uniform window at the boundary.
-    This is a thin wrapper around the truncated_color_laplace distribution to
-    provide a consistent interface with other drift kernels.
+    truncated Laplace distribution, centered at the previous color. Values may
+    go outside of the valid color range ([0.0, 1.0]^3).
 
-    Support: [0.0, 1.0]
+    Support: [-inf, inf]^3
     """
 
     scale: float = Pytree.static()
-    uniform_window_size: float = Pytree.static(default=_FIXED_COLOR_UNIFORM_WINDOW)
 
     def sample(self, key: PRNGKey, prev_value: ArrayLike) -> ArrayLike:
         return genjax.laplace.sample(key, prev_value, self.scale)

--- a/tests/gen3d/test_pixel_rgbd_kernels.py
+++ b/tests/gen3d/test_pixel_rgbd_kernels.py
@@ -1,14 +1,12 @@
 import jax
 import jax.numpy as jnp
 import pytest
-from b3d.chisight.gen3d.pixel_kernels.pixel_color_kernels import (
-    FullPixelColorDistribution,
-)
-from b3d.chisight.gen3d.pixel_kernels.pixel_depth_kernels import (
+from b3d.chisight.gen3d.pixel_kernels import (
     DEPTH_NONRETURN_VAL,
+    FullPixelColorDistribution,
     FullPixelDepthDistribution,
+    PixelRGBDDistribution,
 )
-from b3d.chisight.gen3d.pixel_kernels.pixel_rgbd_kernels import PixelRGBDDistribution
 
 near = 0.01
 far = 20.0
@@ -20,7 +18,7 @@ sample_kernels_to_test = [
             FullPixelDepthDistribution(near, far),
         ),
         (
-            0.01,  # rgb_scale
+            0.01,  # color_scale
             0.01,  # depth_scale
             1 - 0.3,  # visibility_prob
             0.1,  # depth_nonreturn_prob
@@ -92,3 +90,37 @@ def test_relative_logpdf(kernel_spec):
     assert logpdf_5 > logpdf_6
     # the score of the pixel should be higher when the rgbd is closer
     assert logpdf_5 > logpdf_3
+
+
+@pytest.mark.parametrize("kernel_spec", sample_kernels_to_test)
+def test_invalid_pixel(kernel_spec):
+    kernel, additional_args = kernel_spec
+
+    # Latent value of [-1, -1, -1, -1] indicates no point hits here.
+    latent_rgbd = -jnp.ones(4)
+    logpdf_1 = kernel.logpdf(
+        jnp.array([1.0, 0.5, 0.2, 4.0]), latent_rgbd, *additional_args
+    )
+    logpdf_2 = kernel.logpdf(
+        jnp.array([0.0, 0.0, 0.0, 0.02]), latent_rgbd, *additional_args
+    )
+    # the observation does not affect the logpdf
+    assert logpdf_1 == logpdf_2
+
+    logpdf_3 = kernel.logpdf(
+        jnp.array([1.0, 0.5, 0.2, 4.0]), latent_rgbd, 0.1, 0.4, 0.2, 0.1
+    )
+    logpdf_4 = kernel.logpdf(
+        jnp.array([0.0, 0.0, 0.0, 0.02]), latent_rgbd, 0.3, 0.5, 0.4, 0.2
+    )
+    # and the values of the parameters doesn't matter either
+    assert logpdf_2 == logpdf_3
+    assert logpdf_3 == logpdf_4
+
+    # IMPORTANT: note that, by designed, every pixel should have a valid color,
+    # and an observation of [-1, -1, -1, -1] is actually not within the support
+    # of the pixel distribution.
+    logpdf_5 = kernel.logpdf(
+        jnp.array([-1.0, -1.0, -1.0, -1.0]), latent_rgbd, *additional_args
+    )
+    assert logpdf_5 == -jnp.inf


### PR DESCRIPTION
This PR includes some additional tests to make sure the behavior of the `logpdf` method is what we expect when it receives invalid RGBD values (`[-1., -1., -1., -1.]`). Since the distribution is defined on the pixel level, it doesn't really expect the observed RGBD to be invalid, so when we use it to vmap over vertices, we need to handle the case where a vertex does not hit the image plane manually. I'm also updating the image kernel slightly to make sure that we can handle those corner cases.

(note that this is different from the case where a pixel does not have an associated vertex, which can be handle natively in the pixel distribution)


# Test Plan

```bash
pytest tests/gen3d/test_pixel_rgbd_kernels.py
```