### PR TITLE
Metric compute (1/2): Loader for precomputed YCBV pose tracking result

### DIFF
--- a/src/b3d/chisight/gen3d/metrics.py
+++ b/src/b3d/chisight/gen3d/metrics.py
@@ -1,0 +1,49 @@
+from pathlib import Path
+
+import jax.numpy as jnp
+from genjax import Pytree
+from genjax.typing import FloatArray
+
+from b3d.utils import get_assets_path
+
+FP_RESULTS_ROOT_DIR = (
+    get_assets_path() / "shared_data_bucket/foundation_pose_tracking_results"
+)
+DEFAULT_FP_YCBV_RESULT_DIR = (
+    FP_RESULTS_ROOT_DIR / "ycbv/2024-07-11-every-50-frames-gt-init"
+)
+
+
+@Pytree.dataclass
+class YCBVTrackingResultLoader(Pytree):
+    """A utility class that loads precomputed YCBV tracking results from the
+    specified directory as commanded. Note that this dataclass itself does not
+    keep a copy of the result
+    """
+
+    result_dir: Path
+
+    def load(self, test_scene_id: IndentationError, object_id: int) -> FloatArray:
+        """Given the test scene and object id, load the corresponding tracking
+        result from the specified directory. The returning JAX array will have
+        shape (num_frames, 4, 4), where the estimated pose in each frame is
+        stored as a 4x4 transformation matrix.
+        """
+        filename = self.result_dir / str(test_scene_id) / f"object_{object_id}.npy"
+        return jnp.load(filename)
+
+    def get_scene_ids(self) -> list[int]:
+        return sorted(
+            [int(test_scene.name) for test_scene in self.result_dir.iterdir()]
+        )
+
+    def get_object_ids(self, test_scene_id: int) -> list[int]:
+        scene_dir = self.result_dir / str(test_scene_id)
+        prefix_length = len("object_")
+        return sorted(
+            [int(object_id.stem[prefix_length:]) for object_id in scene_dir.iterdir()]
+        )
+
+
+# a default loader for the most recently computed foundation pose tracking results
+foundation_pose_ycbv_result = YCBVTrackingResultLoader(DEFAULT_FP_YCBV_RESULT_DIR)

--- a/tests/gen3d/test_metrics.py
+++ b/tests/gen3d/test_metrics.py
@@ -1,0 +1,24 @@
+import pytest
+from b3d.chisight.gen3d.metrics import (
+    FP_RESULTS_ROOT_DIR,
+    foundation_pose_ycbv_result,
+)
+
+TEST_FP_YCBV_RESULT_DIR = (
+    FP_RESULTS_ROOT_DIR / "ycbv/2024-07-11-every-50-frames-gt-init"
+)
+
+
+@pytest.mark.skipif(
+    not TEST_FP_YCBV_RESULT_DIR.exists(),
+    reason="No foundation pose tracking results found.",
+)
+def test_loading_precomputed_ycbv_results():
+    precomputed_poses = foundation_pose_ycbv_result.load(test_scene_id=48, object_id=1)
+    assert precomputed_poses.shape == (45, 4, 4)
+
+    test_scenes = foundation_pose_ycbv_result.get_scene_ids()
+    assert len(test_scenes) == 12
+
+    obj_ids_scene_48 = foundation_pose_ycbv_result.get_object_ids(test_scene_id=48)
+    assert len(obj_ids_scene_48) == 5


### PR DESCRIPTION
This PR introduces some utility snippets to load the precomputed YCBV results from FoundationPose so that we can make some comparisons.

To fetch the precomputed results, use the `b3d_pull` command. e.g.

```bash
python -m b3d.bucket_utils.b3d_pull
```
This should fetch and place the precomputed results under `assets/shared_data_bucket/foundation_pose_tracking_results`. 

Some examples on how to use this loader can be found in the test file in this PR. It can also be used to make sure that the results are fetched correctly:

```bash
pytest tests/gen3d/test_metrics.py
```

I'm going to put together another PR to compute the actual metrics in a bit...