### PR TITLE
Script to compute quantitative metrics by loading poses from disk

### DIFF
--- a/scripts/get_ycbv_metrics.py
+++ b/scripts/get_ycbv_metrics.py
@@ -1,0 +1,109 @@
+from functools import partial
+from pathlib import Path
+
+import b3d
+import fire
+import numpy as np
+import pandas as pd
+from b3d.chisight.gen3d.metrics import (
+    add_err,
+    adds_err,
+    compute_auc,
+    foundation_pose_ycbv_result,
+)
+from b3d.io.data_loader import YCB_MODEL_NAMES
+from tqdm.auto import tqdm
+
+YCB_DIR = b3d.get_assets_path() / "bop/ycbv"
+
+ALL_METRICS = {
+    "ADD-S": adds_err,
+    "ADD": add_err,
+}
+
+FRAME_RATE = 50
+
+
+def collect_all_scores(get_pose_fn: callable):
+    # e.g. all_score["ADD"]["002_master_chef_can"] gives the ADD error for the
+    # object "002_master_chef_can"
+    all_scores = {}
+    for metric_name in ALL_METRICS:
+        all_scores[metric_name] = {obj_name: [] for obj_name in YCB_MODEL_NAMES}
+
+    # preload all gt meshes
+    meshes = []
+    for obj_id in range(len(YCB_MODEL_NAMES)):
+        obj_id_str = str(obj_id + 1).rjust(6, "0")
+        meshes.append(
+            b3d.Mesh.from_obj_file(YCB_DIR / f"models/obj_{obj_id_str}.ply").scale(
+                0.001
+            )
+        )
+
+    for test_scene_id in range(48, 60):
+        num_scenes = b3d.io.data_loader.get_ycbv_num_test_images(YCB_DIR, test_scene_id)
+        image_ids = range(1, num_scenes + 1, FRAME_RATE)
+        print(f"Processing test scene {test_scene_id}")
+        all_data = b3d.io.data_loader.get_ycbv_test_images(
+            YCB_DIR, test_scene_id, image_ids
+        )
+
+        object_types = all_data[0]["object_types"]
+        for idx, obj_id in tqdm(enumerate(object_types), desc="Processing objects"):
+            obj_name = YCB_MODEL_NAMES[obj_id]
+            obj_mesh = meshes[obj_id]
+            pred_poses = get_pose_fn(test_scene_id, idx)
+            # start computing the error for this object
+            for frame_data, pred_pose in zip(all_data, pred_poses):
+                # load ground truth pose
+                camera_pose = frame_data["camera_pose"]
+                obj_pose = frame_data["object_poses"][idx]
+                gt_pose = (camera_pose.inv() @ obj_pose).as_matrix()
+                # metrics
+                for metric_name, metric_fn in ALL_METRICS.items():
+                    all_scores[metric_name][obj_name].append(
+                        metric_fn(pred_pose, gt_pose, obj_mesh.vertices)
+                    )
+
+    # aggregate results per object
+    final_results = {}
+    for metric_name in ALL_METRICS:
+        final_results[metric_name] = {}
+        for obj_name in YCB_MODEL_NAMES:
+            final_results[metric_name][obj_name] = compute_auc(
+                all_scores[metric_name][obj_name]
+            )
+
+    return pd.DataFrame(final_results), all_scores
+
+
+def get_fp_pred_pose(test_scene_id: int, obj_id: int):
+    return foundation_pose_ycbv_result.load(test_scene_id, obj_id)
+
+
+def get_b3d_pred_pose(result_dir: Path, test_scene_id: int, obj_id: int):
+    poses = np.load(
+        result_dir / f"SCENE_{test_scene_id}_OBJECT_INDEX_{obj_id}_POSES.npy",
+    )
+    poses = b3d.Pose(poses["position"], poses["quaternion"])
+    return poses.as_matrix()
+
+
+def main(b3d_result_dir: str, output_dir: str | None = None):
+    result_dir = Path(b3d_result_dir)
+    if output_dir is None:
+        output_dir = b3d_result_dir
+    output_dir = Path(output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    pred_score_getter = partial(get_b3d_pred_pose, result_dir)
+    # pred_score_getter = get_fp_pred_pose
+    results_summary, _ = collect_all_scores(pred_score_getter)
+    print(results_summary)
+    if output_dir is not None:
+        results_summary.to_csv(output_dir / "summary.csv")
+
+
+if __name__ == "__main__":
+    fire.Fire(main)


### PR DESCRIPTION
Usage

```bash
python <pose_tracking_result_dir> <output_dir>
```

This script will load the precomputed pose tracking results on YCB-V dataset and compute the aggregated ADD and ADD-S metrics per object. It will print out the result and store them in a CSV format in the output directory (if not provided, the output directory will be set to the input directory by default)

Example outputs:
```
                          ADD-S       ADD
002_master_chef_can    0.865135  0.497027
003_cracker_box        0.686422  0.667845
004_sugar_box          0.980075  0.962711
005_tomato_soup_can    0.568405  0.381333
006_mustard_bottle     0.965702  0.534649
007_tuna_fish_can      0.379667  0.255333
008_pudding_box        0.647143  0.549286
009_gelatin_box        0.480714  0.365000
010_potted_meat_can    0.655817  0.510817
011_banana             0.984375  0.962031
019_pitcher_base       0.976282  0.958077
021_bleach_cleanser    0.966097  0.935419
024_bowl               0.768561  0.113258
025_mug                0.540915  0.395854
035_power_drill        0.757128  0.719007
036_wood_block         0.958243  0.901757
037_scissors           0.971098  0.940854
040_large_marker       0.555329  0.400526
051_large_clamp        0.729881  0.433571
052_extra_large_clamp  0.952831  0.308614
061_foam_brick         0.265658  0.148158
```