### PR TITLE
translation/rotation gridding

### DIFF
--- a/src/b3d/pose/grid.py
+++ b/src/b3d/pose/grid.py
@@ -140,17 +140,30 @@ def make_translation_grid_enumeration(
 
 def pose_grid(
     pose_center: Pose,
-    half_dx=float,
-    half_dy=float,
-    half_dz=float,
-    half_nx=int,
-    half_ny=int,
-    half_nz=int,
-    half_dangle=float,
-    half_n_xrot=int,
-    half_n_yrot=int,
-    half_n_zrot=int,
+    half_dx: float,
+    half_dy: float,
+    half_dz: float,
+    half_nx: int,
+    half_ny: int,
+    half_nz: int,
+    half_dangle: float,
+    half_n_xrot: int,
+    half_n_yrot: int,
+    half_n_zrot: int,
 ) -> Pose:
+    """
+    Returns:
+        A batched Pose object.
+
+    Args:
+        pose_center: the center pose
+        half_dx, dy, dz: half the step size for the x, y, z dimension
+        half_nx, ny, nz: half the number of samples in the x, y, z dimension
+            (2n + 1 samples will be used per dimension)
+        half_dangle: half the step size for the euler angle
+        half_n_xrot, half_n_yrot, half_n_zrot: half the number of samples in the x, y, z rotation
+            (2n + 1 samples will be used per dimension)
+    """
     tr_grid = make_translation_grid_enumeration(
         half_dx, half_dy, half_dz, half_nx, half_ny, half_nz
     )
@@ -167,128 +180,3 @@ def pose_grid(
     total_grid = _total_grid.reshape(-1)
 
     return total_grid
-
-
-if __name__ == "__main__":
-    #################################
-    # Setup test
-    #################################
-    VIZ_TEST = False  # toggle to visualize all grid on rerun
-
-    # center pose
-    xyz0 = jnp.array([0.0, 0.0, 0.0])
-    rot0 = jnp.array([0.0, 0.0, 0.0, 1.0])
-    pose0 = Pose(xyz0, rot0)
-
-    # translation grid
-    half_nx = half_ny = half_nz = 2
-    ntr = (2 * half_nx + 1) * (2 * half_ny + 1) * (2 * half_nz + 1)
-    print(f"Generating {ntr} translations")
-    half_dx, half_dy, half_dz = 1, 1, 0.001
-
-    # rotation grid
-    half_n_alpha = half_n_beta = half_n_gamma = 2
-    half_d_euler = jnp.pi / 3
-    nrot = (2 * half_n_alpha + 1) * (2 * half_n_beta + 1) * (2 * half_n_gamma + 1)
-    print(f"Generating {nrot} rotations")
-
-    ##################################
-    # Generate pose grid
-    ##################################
-
-    pose_grid_jit = jax.jit(
-        pose_grid,
-        static_argnames=(
-            "half_nx",
-            "half_ny",
-            "half_nz",
-            "half_n_xrot",
-            "half_n_yrot",
-            "half_n_zrot",
-        ),
-    )
-    grid = pose_grid_jit(
-        pose0,
-        half_dx=half_dx,
-        half_dy=half_dy,
-        half_dz=half_dz,
-        half_nx=half_nx,
-        half_ny=half_ny,
-        half_nz=half_nz,
-        half_dangle=half_d_euler,
-        half_n_xrot=half_n_alpha,
-        half_n_yrot=half_n_beta,
-        half_n_zrot=half_n_gamma,
-    )
-
-    ##################################
-    # Test correctness
-    ##################################
-    # 1a. sanity check sizes
-    assert isinstance(
-        grid, Pose
-    ), f"Wrong return type; expected b3d.Pose, got {type(grid)}"
-    assert grid.pos.shape == (
-        ntr * nrot,
-        3,
-    ), f"Wrong shape for pos; expected {(ntr * nrot, 3)}, got {grid.pos.shape}"
-    assert grid.quaternion.shape == (
-        ntr * nrot,
-        4,
-    ), f"Wrong shape for quat; expected {(ntr * nrot, 4)}, got {grid.quaternion.shape}"
-
-    # 1b. check that original pose is in grid
-    assert (
-        grid.pos.tolist().index(pose0.pos.tolist())
-        == grid.quat.tolist().index(pose0.quat.tolist())
-        != -1
-    ), "Center pose not in grid"
-    print("Size checks and center-pose checks passed")
-
-    # 2. visualize grid
-    if VIZ_TEST:
-        print(f"Visualizing {ntr*nrot} poses in rerun...")
-        viz_from_grid(grid, rerun_session_name=f"GRID_{ntr}_{nrot}", ycb_obj_id=13)
-    else:
-        print("Skipping visualization...")
-
-    # ##################################
-    # # Test time
-    # ##################################
-    import time
-
-    print("Testing jitted runtime...")
-    start = time.time()
-    timed_grid = pose_grid_jit(
-        pose0,
-        half_dx=half_dx,
-        half_dy=half_dy,
-        half_dz=half_dz,
-        half_nx=half_nx,
-        half_ny=half_ny,
-        half_nz=half_nz,
-        half_dangle=half_d_euler,
-        half_n_xrot=half_n_alpha,
-        half_n_yrot=half_n_beta,
-        half_n_zrot=half_n_gamma,
-    )
-    end = time.time()
-    print(f"Time taken: {(end-start)*1000} milliseconds for {ntr*nrot} poses")
-
-    # ### Visualize ###
-    # viz_grid = pose_grid_jit(
-    #     pose0,
-    #     half_dx=half_dx,
-    #     half_dy=half_dy,
-    #     half_dz=half_dz,
-    #     half_nx=half_nx,
-    #     half_ny=half_ny,
-    #     half_nz=half_nz,
-    #     half_dangle=half_d_euler,
-    #     half_n_xrot=half_n_alpha,
-    #     half_n_yrot=half_n_beta,
-    #     half_n_zrot=half_n_gamma,
-    # )
-    # b3d.rr_init("pose_grid_test")
-    # rr_log_pose_arrows_grid(viz_grid)
-    # b3d.rr_log_pose(pose0, channel="original_pose")

--- a/src/b3d/pose/grid.py
+++ b/src/b3d/pose/grid.py
@@ -1,0 +1,250 @@
+import jax
+import jax.numpy as jnp
+
+from .core import Pose
+
+
+def angle_axis_helper_edgecase(newZ):
+    zUnit = jnp.array([0.0, 0.0, 1.0])
+    axis = jnp.array([0.0, 1.0, 0.0])
+    geodesicAngle = jax.lax.cond(
+        jnp.allclose(newZ, zUnit, atol=1e-3),
+        lambda: 0.0,
+        lambda: jnp.pi,  # noqa: E731
+    )
+    return axis, geodesicAngle
+
+
+def angle_axis_helper(newZ):
+    zUnit = jnp.array([0.0, 0.0, 1.0])
+    axis = jnp.cross(zUnit, newZ)
+    theta = jax.lax.asin(jax.lax.clamp(-1.0, jnp.linalg.norm(axis), 1.0))
+    geodesicAngle = jax.lax.cond(
+        jnp.dot(zUnit, newZ) > 0,
+        lambda: theta,
+        lambda: jnp.pi - theta,  # noqa: E731
+    )
+    return axis, geodesicAngle
+
+
+def axis_angle_to_quaternion(axis, angle):
+    # Normalize the axis to ensure it's a unit vector
+    direction = axis / jnp.linalg.norm(axis)
+
+    # Half-angle for quaternion computation
+    half_angle = angle / 2.0
+    sina = jnp.sin(half_angle)
+    cosa = jnp.cos(half_angle)
+
+    # Quaternion components
+    q_w = cosa  # Scalar part
+    q_x = direction[0] * sina  # x-component
+    q_y = direction[1] * sina  # y-component
+    q_z = direction[2] * sina  # z-component
+
+    # Return quaternion (scalar last)
+    return jnp.array([q_x, q_y, q_z, q_w])
+
+
+def geodesicHopf_rotate_within_axis(newZ, planarAngle):
+    """
+    Rotate an axis in 3D space by a planar angle
+    """
+    # newZ should be a normalized vector
+    # returns a 4x4 quaternion
+    zUnit = jnp.array([0.0, 0.0, 1.0])
+
+    # todo: implement cases where newZ is approx. -zUnit or approx. zUnit
+    axis, geodesicAngle = jax.lax.cond(
+        jnp.allclose(jnp.abs(newZ), zUnit, atol=1e-3),
+        angle_axis_helper_edgecase,
+        angle_axis_helper,
+        newZ,
+    )
+    left_pose = Pose(
+        jnp.array([0, 0, 0]), axis_angle_to_quaternion(axis, geodesicAngle)
+    )
+    right_pose = Pose(
+        jnp.array([0, 0, 0]), axis_angle_to_quaternion(zUnit, planarAngle)
+    )
+
+    return left_pose @ right_pose
+
+
+def fibonacci_sphere(samples_in_range, phi_range=jnp.pi):
+    ga = jnp.pi * (jnp.sqrt(5) - 1)  # golden angle
+    eps = 1e-10
+    min_y = jnp.cos(phi_range)
+
+    samples = jnp.round(samples_in_range * (2 / (1 - min_y + eps)))
+
+    def fib_point(i):
+        y = 1 - (i / (samples - 1)) * 2  # goes from 1 to -1
+        radius = jnp.sqrt(1 - y * y)
+        theta = ga * i
+        x = jnp.cos(theta) * radius
+        z = jnp.sin(theta) * radius
+        return jnp.array([x, z, y])
+
+    fib_sphere = jax.vmap(fib_point, in_axes=(0))
+    points = jnp.arange(samples_in_range)
+    return fib_sphere(points)
+
+
+def make_rotation_grid_enumeration(
+    num_fibonacci_sphere_points,  # 5
+    num_axis_rotations,  # 2
+    min_rot_angle,
+    max_rot_angle,
+    sphere_angle_range,
+) -> Pose:
+    """
+    Generate uniformly spaced rotation proposals around a constrained region of SO(3)
+
+    Params:
+    num_fibonacci_sphere_points: number of rotation axes to sample, on the region of the fibonacci sphere specified by `sphere_angle_range`
+    num_axis_rotations: number of in-axis rotations to sample, in the interval [min_rot_angle, max_rot_angle]
+    min_rot_angle, max_rot_angle: the minimum and maximum rotation angle values; max_rot_angle - min_rot_angle leq 2*pi
+    sphere_angle_range: the maximum phi angle (in spherical coordinates) that bounds the region of the fibonacci sphere to sample rotation axes from; sphere_angle_range leq pi
+
+    Returns:
+    rotation proposals: b3d.Pose type with length (fib_sample*rot_sample)
+    """
+    unit_sphere_directions = fibonacci_sphere(
+        num_fibonacci_sphere_points, sphere_angle_range
+    )
+    in_axis_spin = jnp.linspace(min_rot_angle, max_rot_angle, num_axis_rotations)
+
+    inner_vmap = lambda axis_rot: jax.vmap(  # noqa:E731
+        geodesicHopf_rotate_within_axis, in_axes=(None, 0)
+    )(axis_rot, in_axis_spin)
+
+    _proposals = jax.vmap(inner_vmap, in_axes=(0,))(unit_sphere_directions)
+    proposals = _proposals.reshape(num_fibonacci_sphere_points * num_axis_rotations)
+
+    return proposals
+
+
+def make_translation_grid_enumeration(
+    min_x, min_y, min_z, max_x, max_y, max_z, num_x, num_y, num_z
+):
+    """
+    Generate uniformly spaced translation proposals in a 3D box
+    Args:
+        min_x, min_y, min_z: minimum x, y, z values
+    """
+    deltas = jnp.stack(
+        jnp.meshgrid(
+            jnp.linspace(min_x, max_x, num_x),
+            jnp.linspace(min_y, max_y, num_y),
+            jnp.linspace(min_z, max_z, num_z),
+        ),
+        axis=-1,
+    )
+    deltas = deltas.reshape((-1, 3), order="F")
+
+    return Pose(deltas, jnp.tile(Pose.identity_quaternion, (num_x * num_y * num_z, 1)))
+
+
+def pose_grid(
+    pose_center: Pose,
+    min_x: float,
+    min_y: float,
+    min_z: float,
+    max_x: float,
+    max_y: float,
+    max_z: float,
+    nx: int,
+    ny: int,
+    nz: int,
+    min_r: float,
+    max_r: float,
+    d_sph: float,
+    nfib: int,
+    naxis: int,
+) -> jnp.ndarray:
+    tr_grid = make_translation_grid_enumeration(
+        min_x, min_y, min_z, max_x, max_y, max_z, nx, ny, nz
+    )
+    rot_grid = make_rotation_grid_enumeration(nfib, naxis, min_r, max_r, d_sph)
+
+    compose_pose = lambda tr, rot: pose_center.compose(tr).compose(rot)  # noqa:E731
+    inner_vmap = lambda tr: jax.vmap(compose_pose, in_axes=(None, 0))(  # noqa:E731
+        tr, rot_grid
+    )
+    _total_grid = jax.vmap(inner_vmap, in_axes=(0,))(tr_grid)  # vmap over tr
+
+    total_grid = _total_grid.reshape(-1)
+
+    return total_grid
+
+
+if __name__ == "__main__":
+    import time
+
+    xyz0 = jnp.array([0.0, 0.0, 0.0])
+    rot0 = jnp.array([0.0, 0.0, 0.0, 1.0])
+    pose0 = Pose(xyz0, rot0)
+
+    # grid size (translation)
+    nx, ny, nz = 5, 5, 5
+    ntr = nx * ny * nz
+
+    # grid size (rotation)
+    nfib, naxis = 10, 10
+    nrot = nfib * naxis
+
+    pose_grid_jit = jax.jit(
+        pose_grid, static_argnames=("nx", "ny", "nz", "nfib", "naxis")
+    )
+    grid = pose_grid_jit(
+        pose0,
+        min_x=-1,
+        min_y=-1,
+        min_z=-1,
+        max_x=1,
+        max_y=1,
+        max_z=1,
+        nx=nx,
+        ny=ny,
+        nz=ny,
+        min_r=-jnp.pi,
+        max_r=jnp.pi,
+        d_sph=jnp.pi,
+        nfib=nfib,
+        naxis=naxis,
+    )
+
+    # sanity check sizes
+    assert isinstance(
+        grid, Pose
+    ), f"Wrong return type; expected b3d.Pose, got {type(grid)}"
+    assert grid.pos.shape == (
+        ntr * nrot,
+        3,
+    ), f"Wrong shape for pos; expected {(ntr * nrot, 3)}, got {grid.pos.shape}"
+    assert grid.quaternion.shape == (
+        ntr * nrot,
+        4,
+    ), f"Wrong shape for quat; expected {(ntr * nrot, 4)}, got {grid.quaternion.shape}"
+
+    start = time.time()
+    timed_grid = pose_grid_jit(
+        pose0,
+        min_x=-1,
+        min_y=-1,
+        min_z=-1,
+        max_x=1,
+        max_y=1,
+        max_z=1,
+        nx=nx,
+        ny=ny,
+        nz=ny,
+        min_r=-jnp.pi,
+        max_r=jnp.pi,
+        d_sph=jnp.pi,
+        nfib=nfib,
+        naxis=naxis,
+    )
+    end = time.time()
+    print(f"Time taken: {(end-start)*1000} milliseconds for {ntr*nrot} poses")

--- a/src/b3d/pose/grid.py
+++ b/src/b3d/pose/grid.py
@@ -13,7 +13,7 @@ from b3d import Mesh
 from .core import Pose
 
 
-def viz_rotation(pose, vertices, t=0, channel="scene/transformed_mesh"):
+def viz_rotation(pose, vertices, t=0, channel="mesh/xfm_cloud"):
     """visualize a rotation of a given mesh vertex set in rerun"""
     b3d.rr_set_time(t)
 
@@ -32,7 +32,7 @@ def viz_rotation(pose, vertices, t=0, channel="scene/transformed_mesh"):
             media_type=rr.MediaType.MARKDOWN,
         ),
     )
-    b3d.rr_log_pose(pose, "pose/xfm_pose")
+    b3d.rr_log_pose(pose, "axes/xfm_pose_axes")
 
 
 def viz_from_grid(pose_grid, rerun_session_name="grid_test", ycb_obj_id=13):
@@ -48,12 +48,25 @@ def viz_from_grid(pose_grid, rerun_session_name="grid_test", ycb_obj_id=13):
 
     # setup viz
     b3d.rr_init(rerun_session_name)
-    b3d.rr_log_pose(Pose.identity(), "pose/default_pose")
-    viz_rotation(Pose.identity(), mesh_vertices, 0, "pose/default_pose")
+
+    # log the default pose
+    b3d.rr_set_time(0)
+    b3d.rr_log_pose(Pose.identity(), "axes/default_pose_axes")
+    viz_rotation(Pose.identity(), mesh_vertices, 0, "mesh/default_pose_cloud")
 
     # visualize
     for t, pose_viz in enumerate(pose_grid):
-        viz_rotation(pose_viz, mesh_vertices, t + 1)
+        viz_rotation(pose_viz, mesh_vertices, t + 1, "mesh/xfm_cloud")
+
+
+def sorted_linspace(delta, half_num):
+    if half_num == 0:  # only the zero-transform sample is returned
+        return jnp.array([0.0])
+
+    num_samples = half_num * 2 + 1
+    linspace = jnp.linspace(-delta, delta, num_samples)
+    ordered_linspace = linspace[jnp.argsort(jnp.abs(linspace))]
+    return ordered_linspace
 
 
 def rr_log_pose_arrows_grid(pose_grid, channel="pose_grid", scale=0.02):
@@ -65,19 +78,18 @@ def rr_log_pose_arrows_grid(pose_grid, channel="pose_grid", scale=0.02):
 
 
 def make_rotation_grid_enumeration(
-    min_angle,
-    max_angle,
-    n_alpha,
-    n_beta,
-    n_gamma,
+    half_d_angle,
+    half_n_alpha,
+    half_n_beta,
+    half_n_gamma,
 ) -> Pose:
     """
     Enumerate rotations via euler angles uniformly gridded in the range [min_angle, max_angle]
     for each axis (angle of axes: X = alpha, Y = beta, Z = gamma)
     """
-    alphas = jnp.linspace(min_angle, max_angle, n_alpha)
-    betas = jnp.linspace(min_angle, max_angle, n_beta)
-    gammas = jnp.linspace(min_angle, max_angle, n_gamma)
+    alphas = sorted_linspace(half_d_angle, half_n_alpha)
+    betas = sorted_linspace(half_d_angle, half_n_beta)
+    gammas = sorted_linspace(half_d_angle, half_n_gamma)
 
     # nest vmap over all axes
     def _inner_proposal(alpha, beta, gamma):
@@ -89,6 +101,11 @@ def make_rotation_grid_enumeration(
     _proposal_zy = lambda gamma: jax.vmap(_proposal_z, in_axes=(None, 0))(gamma, betas)  # noqa:E731
     proposal_zyx = jax.vmap(_proposal_zy, in_axes=(0,))(gammas)
 
+    n_alpha, n_beta, n_gamma = (
+        2 * half_n_alpha + 1,
+        2 * half_n_beta + 1,
+        2 * half_n_gamma + 1,
+    )
     return Pose(
         jnp.zeros((n_alpha * n_beta * n_gamma, 3)),
         proposal_zyx.as_quat().reshape(-1, 4),
@@ -96,48 +113,49 @@ def make_rotation_grid_enumeration(
 
 
 def make_translation_grid_enumeration(
-    min_x, min_y, min_z, max_x, max_y, max_z, num_x, num_y, num_z
-):
+    half_dx, half_dy, dz, half_num_x, half_num_y, half_num_z
+) -> Pose:
     """
     Generate uniformly spaced translation proposals in a 3D box
     Args:
-        min_x, min_y, min_z: minimum x, y, z values
+        half_dx, half_dy, dz: half-dimension of each of the x, y, z directions
+        half_num_x, half_num_y, half_num_z: samples in each of the dimensions, EXCLUDING the zero sample.
     """
+    x_space = sorted_linspace(half_dx, half_num_x)
+    y_space = sorted_linspace(half_dy, half_num_y)
+    z_space = sorted_linspace(dz, half_num_z)
     deltas = jnp.stack(
         jnp.meshgrid(
-            jnp.linspace(min_x, max_x, num_x),
-            jnp.linspace(min_y, max_y, num_y),
-            jnp.linspace(min_z, max_z, num_z),
+            x_space,
+            y_space,
+            z_space,
         ),
         axis=-1,
     )
     deltas = deltas.reshape((-1, 3), order="F")
 
+    num_x, num_y, num_z = 2 * half_num_x + 1, 2 * half_num_y + 1, 2 * half_num_z + 1
     return Pose(deltas, jnp.tile(Pose.identity_quaternion, (num_x * num_y * num_z, 1)))
 
 
 def pose_grid(
     pose_center: Pose,
-    min_x: float,
-    min_y: float,
-    min_z: float,
-    max_x: float,
-    max_y: float,
-    max_z: float,
-    nx: int,
-    ny: int,
-    nz: int,
-    min_euler_angle: float,
-    max_euler_angle: float,
-    n_xrot: int,
-    n_yrot: int,
-    n_zrot: int,
-) -> jnp.ndarray:
+    half_dx=float,
+    half_dy=float,
+    half_dz=float,
+    half_nx=int,
+    half_ny=int,
+    half_nz=int,
+    half_dangle=float,
+    half_n_xrot=int,
+    half_n_yrot=int,
+    half_n_zrot=int,
+) -> Pose:
     tr_grid = make_translation_grid_enumeration(
-        min_x, min_y, min_z, max_x, max_y, max_z, nx, ny, nz
+        half_dx, half_dy, half_dz, half_nx, half_ny, half_nz
     )
     rot_grid = make_rotation_grid_enumeration(
-        min_euler_angle, max_euler_angle, n_xrot, n_yrot, n_zrot
+        half_dangle, half_n_xrot, half_n_yrot, half_n_zrot
     )
 
     compose_pose = lambda tr, rot: pose_center.compose(tr).compose(rot)  # noqa:E731
@@ -152,63 +170,61 @@ def pose_grid(
 
 
 if __name__ == "__main__":
+    #################################
+    # Setup test
+    #################################
+    VIZ_TEST = False  # toggle to visualize all grid on rerun
+
     # center pose
     xyz0 = jnp.array([0.0, 0.0, 0.0])
     rot0 = jnp.array([0.0, 0.0, 0.0, 1.0])
     pose0 = Pose(xyz0, rot0)
 
     # translation grid
-    nx = ny = nz = 5
-    ntr = nx * ny * nz
+    half_nx = half_ny = half_nz = 2
+    ntr = (2 * half_nx + 1) * (2 * half_ny + 1) * (2 * half_nz + 1)
     print(f"Generating {ntr} translations")
-    min_x, min_y, min_z = -0.1, -0.1, 0.001
-    max_x, max_y, max_z = 0.1, 0.1, 0.2
+    half_dx, half_dy, half_dz = 1, 1, 0.001
 
     # rotation grid
-    n_alpha = n_beta = n_gamma = 5
-    nrot = n_alpha * n_beta * n_gamma
+    half_n_alpha = half_n_beta = half_n_gamma = 2
+    half_d_euler = jnp.pi / 3
+    nrot = (2 * half_n_alpha + 1) * (2 * half_n_beta + 1) * (2 * half_n_gamma + 1)
     print(f"Generating {nrot} rotations")
-    min_euler, max_euler = -jnp.pi / 6, jnp.pi / 6
 
     ##################################
-    # Translation / Rotation grids
-    ##################################
-    tr_grid = make_translation_grid_enumeration(
-        min_x, min_y, min_z, max_x, max_y, max_z, nx, ny, nz
-    )
-    rot_grid = make_rotation_grid_enumeration(
-        min_euler, max_euler, n_alpha, n_beta, n_gamma
-    )
-
-    ##################################
-    # Whole pose grid
+    # Generate pose grid
     ##################################
 
     pose_grid_jit = jax.jit(
-        pose_grid, static_argnames=("nx", "ny", "nz", "n_xrot", "n_yrot", "n_zrot")
+        pose_grid,
+        static_argnames=(
+            "half_nx",
+            "half_ny",
+            "half_nz",
+            "half_n_xrot",
+            "half_n_yrot",
+            "half_n_zrot",
+        ),
     )
     grid = pose_grid_jit(
         pose0,
-        min_x=min_x,
-        min_y=min_y,
-        min_z=min_z,
-        max_x=max_x,
-        max_y=max_y,
-        max_z=max_z,
-        nx=nx,
-        ny=ny,
-        nz=ny,
-        min_euler_angle=min_euler,
-        max_euler_angle=max_euler,
-        n_xrot=n_alpha,
-        n_yrot=n_beta,
-        n_zrot=n_gamma,
+        half_dx=half_dx,
+        half_dy=half_dy,
+        half_dz=half_dz,
+        half_nx=half_nx,
+        half_ny=half_ny,
+        half_nz=half_nz,
+        half_dangle=half_d_euler,
+        half_n_xrot=half_n_alpha,
+        half_n_yrot=half_n_beta,
+        half_n_zrot=half_n_gamma,
     )
 
     ##################################
     # Test correctness
     ##################################
-    # sanity check sizes
+    # 1a. sanity check sizes
     assert isinstance(
         grid, Pose
     ), f"Wrong return type; expected b3d.Pose, got {type(grid)}"
@@ -221,30 +237,40 @@ if __name__ == "__main__":
         4,
     ), f"Wrong shape for quat; expected {(ntr * nrot, 4)}, got {grid.quaternion.shape}"
 
-    # viz_from_grid(grid, rerun_session_name=f"GRID_{ntr}_{nrot}", ycb_obj_id=13)
+    # 1b. check that original pose is in grid
+    assert (
+        grid.pos.tolist().index(pose0.pos.tolist())
+        == grid.quat.tolist().index(pose0.quat.tolist())
+        != -1
+    ), "Center pose not in grid"
+    print("Size checks and center-pose checks passed")
+
+    # 2. visualize grid
+    if VIZ_TEST:
+        print(f"Visualizing {ntr*nrot} poses in rerun...")
+        viz_from_grid(grid, rerun_session_name=f"GRID_{ntr}_{nrot}", ycb_obj_id=13)
+    else:
+        print("Skipping visualization...")
 
     # ##################################
     # # Test time
     # ##################################
     import time
 
+    print("Testing jitted runtime...")
     start = time.time()
     timed_grid = pose_grid_jit(
         pose0,
-        min_x=min_x,
-        min_y=min_y,
-        min_z=min_z,
-        max_x=max_x,
-        max_y=max_y,
-        max_z=max_z,
-        nx=nx,
-        ny=ny,
-        nz=ny,
-        min_euler_angle=min_euler,
-        max_euler_angle=max_euler,
-        n_xrot=n_alpha,
-        n_yrot=n_beta,
-        n_zrot=n_gamma,
+        half_dx=half_dx,
+        half_dy=half_dy,
+        half_dz=half_dz,
+        half_nx=half_nx,
+        half_ny=half_ny,
+        half_nz=half_nz,
+        half_dangle=half_d_euler,
+        half_n_xrot=half_n_alpha,
+        half_n_yrot=half_n_beta,
+        half_n_zrot=half_n_gamma,
     )
     end = time.time()
     print(f"Time taken: {(end-start)*1000} milliseconds for {ntr*nrot} poses")

--- a/src/b3d/pose/grid.py
+++ b/src/b3d/pose/grid.py
@@ -275,24 +275,20 @@ if __name__ == "__main__":
     end = time.time()
     print(f"Time taken: {(end-start)*1000} milliseconds for {ntr*nrot} poses")
 
-    ### Visualize ###
-    viz_grid = pose_grid_jit(
-        pose0,
-        min_x=min_x,
-        min_y=min_y,
-        min_z=min_z,
-        max_x=max_x,
-        max_y=max_y,
-        max_z=max_z,
-        nx=nx,
-        ny=ny,
-        nz=ny,
-        min_euler_angle=min_euler,
-        max_euler_angle=max_euler,
-        n_xrot=1,
-        n_yrot=1,
-        n_zrot=1,
-    )
-    b3d.rr_init("pose_grid_test")
-    rr_log_pose_arrows_grid(viz_grid)
-    b3d.rr_log_pose(pose0, channel="original_pose")
+    # ### Visualize ###
+    # viz_grid = pose_grid_jit(
+    #     pose0,
+    #     half_dx=half_dx,
+    #     half_dy=half_dy,
+    #     half_dz=half_dz,
+    #     half_nx=half_nx,
+    #     half_ny=half_ny,
+    #     half_nz=half_nz,
+    #     half_dangle=half_d_euler,
+    #     half_n_xrot=half_n_alpha,
+    #     half_n_yrot=half_n_beta,
+    #     half_n_zrot=half_n_gamma,
+    # )
+    # b3d.rr_init("pose_grid_test")
+    # rr_log_pose_arrows_grid(viz_grid)
+    # b3d.rr_log_pose(pose0, channel="original_pose")

--- a/src/b3d/pose/grid.py
+++ b/src/b3d/pose/grid.py
@@ -56,6 +56,14 @@ def viz_from_grid(pose_grid, rerun_session_name="grid_test", ycb_obj_id=13):
         viz_rotation(pose_viz, mesh_vertices, t + 1)
 
 
+def rr_log_pose_arrows_grid(pose_grid, channel="pose_grid", scale=0.02):
+    origins = jnp.tile(pose_grid.pos, (3, 1))
+    colors = jnp.tile(jnp.eye(3), (len(origins), 1))
+    vectors = jax.vmap(lambda pose: pose.as_matrix()[:3, :3].T)(pose_grid) * scale
+    vectors = vectors.reshape(-1, 3)
+    rr.log(channel, rr.Arrows3D(origins=origins, vectors=vectors, colors=colors))
+
+
 def make_rotation_grid_enumeration(
     min_angle,
     max_angle,
@@ -240,3 +248,25 @@ if __name__ == "__main__":
     )
     end = time.time()
     print(f"Time taken: {(end-start)*1000} milliseconds for {ntr*nrot} poses")
+
+    ### Visualize ###
+    viz_grid = pose_grid_jit(
+        pose0,
+        min_x=min_x,
+        min_y=min_y,
+        min_z=min_z,
+        max_x=max_x,
+        max_y=max_y,
+        max_z=max_z,
+        nx=nx,
+        ny=ny,
+        nz=ny,
+        min_euler_angle=min_euler,
+        max_euler_angle=max_euler,
+        n_xrot=1,
+        n_yrot=1,
+        n_zrot=1,
+    )
+    b3d.rr_init("pose_grid_test")
+    rr_log_pose_arrows_grid(viz_grid)
+    b3d.rr_log_pose(pose0, channel="original_pose")

--- a/tests/gen3d/test_posegrid_util.py
+++ b/tests/gen3d/test_posegrid_util.py
@@ -127,21 +127,3 @@ def test_pose_gridding():
     )
     end = time.time()
     print(f"Time taken: {(end-start)*1000} milliseconds for {ntr*nrot} poses")
-
-    # ### Visualize ###
-    # viz_grid = pose_grid_jit(
-    #     pose0,
-    #     half_dx=half_dx,
-    #     half_dy=half_dy,
-    #     half_dz=half_dz,
-    #     half_nx=half_nx,
-    #     half_ny=half_ny,
-    #     half_nz=half_nz,
-    #     half_dangle=half_d_euler,
-    #     half_n_xrot=half_n_alpha,
-    #     half_n_yrot=half_n_beta,
-    #     half_n_zrot=half_n_gamma,
-    # )
-    # b3d.rr_init("pose_grid_test")
-    # rr_log_pose_arrows_grid(viz_grid)
-    # b3d.rr_log_pose(pose0, channel="original_pose")

--- a/tests/gen3d/test_posegrid_util.py
+++ b/tests/gen3d/test_posegrid_util.py
@@ -1,0 +1,147 @@
+import jax
+import jax.numpy as jnp
+from b3d import Pose
+from b3d.pose.grid import pose_grid, viz_from_grid
+
+
+def test_pose_gridding():
+    #################################
+    # Setup test
+    #################################
+    VIZ_TEST = False  # toggle to visualize all grid on rerun
+
+    # center pose
+    xyz0 = jnp.array([0.0, 0.0, 0.0])
+    rot0 = jnp.array([0.0, 0.0, 0.0, 1.0])
+    pose0 = Pose(xyz0, rot0)
+
+    # translation grid
+    half_nx = half_ny = half_nz = 2
+    ntr = (2 * half_nx + 1) * (2 * half_ny + 1) * (2 * half_nz + 1)
+    print(f"Generating {ntr} translations")
+    half_dx, half_dy, half_dz = 1, 1, 0.001
+
+    # rotation grid
+    half_n_alpha = half_n_beta = half_n_gamma = 2
+    half_d_euler = jnp.pi / 3
+    nrot = (2 * half_n_alpha + 1) * (2 * half_n_beta + 1) * (2 * half_n_gamma + 1)
+    print(f"Generating {nrot} rotations")
+
+    ##################################
+    # Generate pose grid
+    ##################################
+
+    pose_grid_jit = jax.jit(
+        pose_grid,
+        static_argnames=(
+            "half_nx",
+            "half_ny",
+            "half_nz",
+            "half_n_xrot",
+            "half_n_yrot",
+            "half_n_zrot",
+        ),
+    )
+    grid = pose_grid_jit(
+        pose0,
+        half_dx=half_dx,
+        half_dy=half_dy,
+        half_dz=half_dz,
+        half_nx=half_nx,
+        half_ny=half_ny,
+        half_nz=half_nz,
+        half_dangle=half_d_euler,
+        half_n_xrot=half_n_alpha,
+        half_n_yrot=half_n_beta,
+        half_n_zrot=half_n_gamma,
+    )
+
+    ##################################
+    # Test correctness
+    ##################################
+    # 1a. sanity check sizes
+    assert isinstance(
+        grid, Pose
+    ), f"Wrong return type; expected b3d.Pose, got {type(grid)}"
+    assert grid.pos.shape == (
+        ntr * nrot,
+        3,
+    ), f"Wrong shape for pos; expected {(ntr * nrot, 3)}, got {grid.pos.shape}"
+    assert grid.quaternion.shape == (
+        ntr * nrot,
+        4,
+    ), f"Wrong shape for quat; expected {(ntr * nrot, 4)}, got {grid.quaternion.shape}"
+
+    # 1b. check that original pose is in grid
+    assert (
+        grid.pos.tolist().index(pose0.pos.tolist())
+        == grid.quat.tolist().index(pose0.quat.tolist())
+        != -1
+    ), "Center pose not in grid"
+    print("Size checks and center-pose checks passed")
+
+    # 2. visualize grid
+    if VIZ_TEST:
+        print(f"Visualizing {ntr*nrot} poses in rerun...")
+        viz_from_grid(grid, rerun_session_name=f"GRID_{ntr}_{nrot}", ycb_obj_id=13)
+    else:
+        print("Skipping visualization...")
+
+    # 3. Test that a 1-pose grid is just the starting point
+    pose_from_grid = pose_grid_jit(
+        pose0,
+        half_dx=half_dx,
+        half_dy=half_dy,
+        half_dz=half_dz,
+        half_nx=0,
+        half_ny=0,
+        half_nz=0,
+        half_dangle=half_d_euler,
+        half_n_xrot=0,
+        half_n_yrot=0,
+        half_n_zrot=0,
+    )[0]
+    assert jnp.allclose(pose_from_grid.position, pose0.position) and jnp.allclose(
+        pose_from_grid.quaternion, pose0.quaternion
+    ), "Single-pose grid not equal to original pose"
+
+    # ##################################
+    # # Test time
+    # ##################################
+    import time
+
+    print("Testing jitted runtime...")
+    start = time.time()
+    _ = pose_grid_jit(
+        pose0,
+        half_dx=half_dx,
+        half_dy=half_dy,
+        half_dz=half_dz,
+        half_nx=half_nx,
+        half_ny=half_ny,
+        half_nz=half_nz,
+        half_dangle=half_d_euler,
+        half_n_xrot=half_n_alpha,
+        half_n_yrot=half_n_beta,
+        half_n_zrot=half_n_gamma,
+    )
+    end = time.time()
+    print(f"Time taken: {(end-start)*1000} milliseconds for {ntr*nrot} poses")
+
+    # ### Visualize ###
+    # viz_grid = pose_grid_jit(
+    #     pose0,
+    #     half_dx=half_dx,
+    #     half_dy=half_dy,
+    #     half_dz=half_dz,
+    #     half_nx=half_nx,
+    #     half_ny=half_ny,
+    #     half_nz=half_nz,
+    #     half_dangle=half_d_euler,
+    #     half_n_xrot=half_n_alpha,
+    #     half_n_yrot=half_n_beta,
+    #     half_n_zrot=half_n_gamma,
+    # )
+    # b3d.rr_init("pose_grid_test")
+    # rr_log_pose_arrows_grid(viz_grid)
+    # b3d.rr_log_pose(pose0, channel="original_pose")


### PR DESCRIPTION
Implements 
```
    grid = pose_grid(
        pose0,   # center of grid
        min_x=min_x,    # translation min/max ranges (x,y,z)
        min_y=min_y,
        min_z=min_z,
        max_x=max_x,
        max_y=max_y,
        max_z=max_z,
        nx=nx,     # translation number of grid points (x,y,z)
        ny=ny,
        nz=ny,
        min_euler_angle=min_euler,     # rotation min/max ranges (x,y,z)
        max_euler_angle=max_euler,
        n_xrot=n_xrot,    # rotations around x axis 
        n_yrot=n_yrot,
        n_zrot=n_zrot,
    )
```
Which produces a uniform translation/rotation grid from a center pose. (Make small note that this is different from the old Bayes3D rotation gridding scheme based on Ben Zinberg's fibonacci lattice division.)

Script also contains a test for visually sanity checking the grid poses on rerun; this code can be moved out/deleted.

Perf benchmark with `jax.jit`: `Time taken: 0.6721019744873047 milliseconds for 15625 poses` 