### PR TITLE
Fix broken CI 

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -42,7 +42,7 @@ jobs:
           export PATH=$HOME/.pixi/bin:$HOME/.local/bin:$PATH
 
           # install pipx and inject gcp backend
-          pixi global install --force-reinstallpipx
+          pixi global install --force-reinstall pipx
           pipx install --force keyring==25.3.0
           pipx inject keyring \
             keyrings.google-artifactregistry-auth \

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -1,4 +1,4 @@
-name: Codebase tests (GPU)
+name: All tests
 
 on:
   pull_request:

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -42,7 +42,7 @@ jobs:
           export PATH=$HOME/.pixi/bin:$HOME/.local/bin:$PATH
 
           # install pipx and inject gcp backend
-          pixi global install pipx
+          pixi global install --force-reinstallpipx
           pipx install --force keyring==25.3.0
           pipx inject keyring \
             keyrings.google-artifactregistry-auth \

--- a/src/b3d/chisight/dynamic_object_model/dynamic_object_inference.py
+++ b/src/b3d/chisight/dynamic_object_model/dynamic_object_inference.py
@@ -3,7 +3,6 @@ import jax.numpy as jnp
 import jax.random
 from genjax import ChoiceMapBuilder as C
 from genjax import Diff
-from genjax import UpdateProblemBuilder as U
 
 from b3d import Pose
 
@@ -29,7 +28,7 @@ def advance_time(key, trace, observed_rgbd):
     previous_state = trace.get_retval()["new_state"]
     trace, _, _, _ = trace.update(
         key,
-        U.g(
+        C.g(
             (Diff.no_change(hyperparams), Diff.unknown_change(previous_state)),
             C.kw(rgbd=observed_rgbd),
         ),


### PR DESCRIPTION
This PR gets CI going again.
1. Upgrades `pytest.yml` to fix [breaking tests](https://github.com/probcomp/b3d/pull/205)
2. Removes `UpdateProblemBuilder` as part of the GenJAX `0.7.0` upgrade